### PR TITLE
Prevent line containing isort:import tripping up over itself

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -599,8 +599,8 @@ class SortImports(object):
                     self.import_index = self.index - 1
                 continue
 
-            if "isort:imports-" in line:
-                section = line.split("isort:imports-")[-1].split()[0]
+            if "isort:" + "imports-" in line:
+                section = line.split("isort:" + "imports-")[-1].split()[0]
                 self.place_imports[section.upper()] = []
                 self.import_placements[line] = section.upper()
 


### PR DESCRIPTION
I ran isort on isort.py and the line for `isort:imports` found and modified itself. Fixing that by breaking up strings.