### PR TITLE
(Hopefully) fixed verbatim string indentation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ own line
 Note: to change the how constant indents appear - simply change the indent property with the following accepted formats:
 *   Number of spaces you would like. For example: 4 would cause standard 4 space indentation.
 *   Tab
-*   A verbatim string with quotes around it. For example: "    " is equivalent to 4
+*   A verbatim string with quotes around it. For example: `"    "` is equivalent to 4
 
 Intelligently Balanced Multi-line Imports
 ======================


### PR DESCRIPTION
The example for a verbatim string ("equivalent to 4") was a set of double quotes with a tab inside it.

* I assume it should be four spaces instead of a tab.
* I added backticks so that the spaces aren't collapsed in html.

The weird thing is that it still shows up as a single space when rendered. I'm submitting the pull request anyway as I assume the tab is wrong. And perhaps you see what needs to be done to get four spaces out of markdown :-)