### PR TITLE
Accept [isort] section in ~/.isort.cfg

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -96,7 +96,7 @@ default = {'force_to_top': [],
 def from_path(path):
     computed_settings = default.copy()
     _update_settings_with_config(path, '.editorconfig', '~/.editorconfig', ('*', '*.py', '**.py'), computed_settings)
-    _update_settings_with_config(path, '.isort.cfg', '~/.isort.cfg', ('settings', ), computed_settings)
+    _update_settings_with_config(path, '.isort.cfg', '~/.isort.cfg', ('settings', 'isort'), computed_settings)
     _update_settings_with_config(path, 'setup.cfg', None, ('isort', ), computed_settings)
     return computed_settings
 


### PR DESCRIPTION
It is a bit weird to have an `[isort]` section in a `setup.cfg` file, but to require a `[settings]` section if it is in `~/.isort.cfg`.

At least, I had to look at the isort source code to figure out why it wasn't picking up my settings :-)