### PR TITLE
 Add Setuptools integration issue #261

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,11 @@ ignore_frosted_errors = E103
 skip = runtests.py,build
 balanced_wrapping = true
 not_skip = __init__.py
+
+[*.{rst,ini}]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
-python:
-  - "pypy"
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-script: python setup.py test
+env:
+  - TOXENV=isort-check
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
+install:
+  - pip install tox
+script:
+  - tox -e $TOXENV

--- a/README.md
+++ b/README.md
@@ -385,7 +385,10 @@ or:
     menu > Python > Remove Import
 
 Using isort to verify code
-======================
+==========================
+
+The ```--check-only``` option
+-----------------------------
 
 isort can also be used to used to verify that code is correctly formatted by running it with -c.
 Any files that contain incorrectly sorted imports will be outputted to stderr.
@@ -403,7 +406,7 @@ Which can help to ensure a certain level of code quality throughout a project.
 
 
 Git hook
-========
+--------
 
 isort provides a hook function that can be integrated into your Git pre-commit script to check
 Python code before committing.
@@ -418,6 +421,31 @@ To cause the commit to fail if there are isort errors (strict mode), include the
 
 If you just want to display warnings, but allow the commit to happen anyway, call git_hook without
 the `strict` parameter.
+
+Setuptools integration
+----------------------
+
+Upon installation, isort enables a setuptools command that checks Python files
+declared by your project.
+
+Running ``python setup.py isort`` on the command line will check the files
+listed in your ``py_modules`` and ``packages``.  If any warning is found,
+the command will exit with an error code::
+
+    $ python setup.py isort
+
+Also, to allow users to be able to use the command without having to install
+isort themselves, add isort to the setup_requires of your setup() like so::
+
+    setup(
+        name="project",
+        packages=["project"],
+
+        setup_requires=[
+            "isort"
+        ]
+    )
+
 
 
 Why isort?

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(name='isort',
       entry_points={
         'console_scripts': [
             'isort = isort.main:main',
-        ]
+        ],
+        'distutils.commands': ['isort = isort.main:ISortCommand'],
       },
       packages=['isort'],
       requires=['pies', 'natsort'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist =
+    isort-check,
+    py26, py27, py32, py33, py34, pypy
 
 [testenv]
-commands = py.test {posargs}
+commands = 
+    py.test {posargs}
 deps =
     pytest
+
+[testenv:isort-check]
+commands = 
+    python setup.py isort
+deps =


### PR DESCRIPTION
These changes enable any user that installs `isort` to check his source
code from setup.py with the command `python setup.py isort`

I also checked isort package code with his command in tox and travis.

Acknowledgements: this is mostly inspired by flake8 setuptools integration,
see [flake8 doc](http://flake8.readthedocs.org/en/2.2.3/setuptools.html)