### PR TITLE
Fix [Error 22] under Windows reading .editorconfig

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -159,7 +159,7 @@ def _as_list(value):
 
 @lru_cache()
 def _get_config_data(file_path, sections):
-    with open(file_path) as config_file:
+    with open(file_path, 'rU') as config_file:
         if file_path.endswith(".editorconfig"):
             line = "\n"
             last_position = config_file.tell()


### PR DESCRIPTION
Under windows system, if the `.editorconfig` file is not CRLF ended, after reading file using `file.readline()`, the `file.tell()` will give negative values, which at last raises `IOError`: "[Errno 22] Invalid argument". 

This patch open config files in "[universal newlines](https://docs.python.org/2/glossary.html#term-universal-newlines)" mode, which treat all line endings as '\n', hopefully fixes this issue.

@timothycrosley, I don't have enough tests, just let you know about this issue. Thanks for providing such awesome program :)