### PR TITLE
Print the number of skipped files, if any

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -47,6 +47,7 @@ SECTIONS = namedtuple('Sections', SECTION_NAMES)(*range(len(SECTION_NAMES)))
 
 class SortImports(object):
     incorrectly_sorted = False
+    skipped = False
 
     def __init__(self, file_path=None, file_contents=None, write_to_stdout=False, check=False,
                  show_diff=False, settings_path=None, **setting_overrides):
@@ -87,6 +88,7 @@ class SortImports(object):
         if file_path and not file_contents:
             file_path = os.path.abspath(file_path)
             if self._should_skip(file_path):
+                self.skipped = True
                 if self.config['verbose']:
                     print("WARNING: {0} was skipped as it's listed in 'skip' setting".format(file_path))
                 file_contents = None

--- a/isort/main.py
+++ b/isort/main.py
@@ -124,16 +124,22 @@ def main():
         wrong_sorted_files = False
         if arguments.get('recursive', False):
             file_names = iter_source_code(file_names)
+        num_skipped = 0
         for file_name in file_names:
             try:
-                incorrectly_sorted = SortImports(file_name, **arguments).incorrectly_sorted
+                sort_attempt = SortImports(file_name, **arguments)
+                incorrectly_sorted = sort_attempt.incorrectly_sorted
                 if arguments.get('check', False) and incorrectly_sorted:
                     wrong_sorted_files = True
+                if sort_attempt.skipped:
+                    num_skipped += 1
             except IOError as e:
                 print("WARNING: Unable to parse file {0} due to {1}".format(file_name, e))
         if wrong_sorted_files:
             exit(1)
 
+        if num_skipped:
+            print("Skipped {0} files".format(num_skipped))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
It wasn't obvious to me that `__init__.py` files were being skipped.  I see that -vb would print each one, but that is also not default.  I think default-skip should at least be visible with a summary line.

$ PYTHONPATH=/Users/jdunck/open-source/isort isort -rc common/
Skipped 11 files
