### PR TITLE
Imports in known stanzas should override stdlib modules

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -211,9 +211,9 @@ class SortImports(object):
         for module_name_to_check in module_names_to_check:
             for placement, config_key in (
                     (SECTIONS.FUTURE, 'known_future_library'),
-                    (SECTIONS.STDLIB, 'known_standard_library'),
                     (SECTIONS.THIRDPARTY, 'known_third_party'),
                     (SECTIONS.FIRSTPARTY, 'known_first_party'),
+                    (SECTIONS.STDLIB, 'known_standard_library'),
                     ):
                 if module_name_to_check in self.config[config_key]:
                     return placement

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [wheel]
 universal = 1
+
+[flake8]
+ignore = F401,F403,E502,E123,E127,E128,E303,E713,E111,E241,E302,E121,E261,W391
+max-line-length = 160

--- a/test_isort.py
+++ b/test_isort.py
@@ -665,6 +665,27 @@ def test_default_section():
                                   "\n"
                                   "import django.settings\n")
 
+def test_first_party_overrides_standard_section():
+    """Test to ensure changing the default section works as expected."""
+    test_input = ("import sys\n"
+                  "import os\n"
+                  "import profile.test\n")
+    test_output = SortImports(file_contents=test_input, known_first_party=['profile']).output
+    assert test_output == ("import os\n"
+                           "import sys\n"
+                           "\n"
+                           "import profile.test\n")
+
+def test_thirdy_party_overrides_standard_section():
+    """Test to ensure changing the default section works as expected."""
+    test_input = ("import sys\n"
+                  "import os\n"
+                  "import profile.test\n")
+    test_output = SortImports(file_contents=test_input, known_third_party=['profile']).output
+    assert test_output == ("import os\n"
+                           "import sys\n"
+                           "\n"
+                           "import profile.test\n")
 
 def test_force_single_line_imports():
     """Test to ensure forcing imports to each have their own line works as expected."""


### PR DESCRIPTION
Hello, 

If a module is defined in known_first_party but has the same name as a stdlib module it would not end up in the first_party section. This pull requests changes that. I believe that is the correct behavior.

I also added a flake8 config to setup.cfg. Without it about 60 lint errors were generated. I'd be happy to fix them in another pull request if you like.