### PR TITLE
Respect the coding declaration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Packages
 *.egg
 *.egg-info
+.eggs
 build
 eggs
 parts

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -756,6 +756,7 @@ def coding_check(fname, default='utf-8'):
     # see https://www.python.org/dev/peps/pep-0263/
     pattern = re.compile(br'coding[:=]\s*([-\w.]+)')
 
+    coding = default
     with io.open(fname, 'rb') as f:
         for line_number, line in enumerate(f, 1):
             groups = re.findall(pattern, line)
@@ -763,7 +764,6 @@ def coding_check(fname, default='utf-8'):
                 coding = groups[0].decode('ascii')
                 break
             if line_number > 2:
-                coding = default
                 break
 
     return coding

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -28,8 +28,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import codecs
 import copy
+import io
 import itertools
 import os
+import re
 from collections import namedtuple
 from datetime import datetime
 from difflib import unified_diff
@@ -83,6 +85,7 @@ class SortImports(object):
         self._section_comments = ["# " + value for key, value in itemsview(self.config) if
                                   key.startswith('import_heading') and value]
 
+        self.file_encoding = 'utf-8'
         file_name = file_path
         self.file_path = file_path or ""
         if file_path and not file_contents:
@@ -94,9 +97,9 @@ class SortImports(object):
                 file_contents = None
             else:
                 self.file_path = file_path
-                with open(file_path) as file_to_import_sort:
+                self.file_encoding = coding_check(file_path)
+                with codecs.open(file_path, encoding=self.file_encoding) as file_to_import_sort:
                     file_contents = file_to_import_sort.read()
-                    file_contents = PY2 and file_contents.decode('utf8') or file_contents
 
         if file_contents is None or ("isort:" + "skip_file") in file_contents:
             return
@@ -159,7 +162,7 @@ class SortImports(object):
         elif write_to_stdout:
             stdout.write(self.output)
         elif file_name:
-            with codecs.open(self.file_path, encoding='utf-8', mode='w') as output_file:
+            with codecs.open(self.file_path, encoding=self.file_encoding, mode='w') as output_file:
                 output_file.write(self.output)
 
     def _show_diff(self, file_contents):
@@ -746,3 +749,21 @@ class SortImports(object):
                                 self.comments['above']['from'].setdefault(module, []).insert(0, self.out_lines.pop(-1))
                                 last = self.out_lines and self.out_lines[-1].rstrip() or ""
                         self.imports[self.place_module(module)][import_type].add(module)
+
+
+def coding_check(fname, default='utf-8'):
+
+    # see https://www.python.org/dev/peps/pep-0263/
+    pattern = re.compile(br'coding[:=]\s*([-\w.]+)')
+
+    with io.open(fname, 'rb') as f:
+        for line_number, line in enumerate(f, 1):
+            groups = re.findall(pattern, line)
+            if groups:
+                coding = groups[0].decode('ascii')
+                break
+            if line_number > 2:
+                coding = default
+                break
+
+    return coding

--- a/test_isort.py
+++ b/test_isort.py
@@ -1,7 +1,7 @@
 """test_isort.py.
 
 Tests all major functionality of the isort library
-Should be ran using py.test by simply running by.test in the isort project directory
+Should be ran using py.test by simply running py.test in the isort project directory
 
 Copyright (C) 2013  Timothy Edmund Crosley
 

--- a/test_isort.py
+++ b/test_isort.py
@@ -1341,8 +1341,8 @@ def test_other_file_encodings():
         for encoding in ('latin1', 'utf8'):
             tmp_fname = os.path.join(tmp_dir, 'test_{}.py'.format(encoding))
             with codecs.open(tmp_fname, mode='w', encoding=encoding) as f:
-                file_contents = "# coding: {}'\ns = u'\u00E3'".format(encoding)
+                file_contents = "# coding: {}\ns = u'\u00E3'\n".format(encoding)
                 f.write(file_contents)
-            assert SortImports(file_path=tmp_fname).output == file_contents
+        assert SortImports(file_path=tmp_fname).output == file_contents
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/test_isort.py
+++ b/test_isort.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 """test_isort.py.
 
 Tests all major functionality of the isort library
@@ -1341,7 +1342,7 @@ def test_other_file_encodings():
         for encoding in ('latin1', 'utf8'):
             tmp_fname = os.path.join(tmp_dir, 'test_{}.py'.format(encoding))
             with codecs.open(tmp_fname, mode='w', encoding=encoding) as f:
-                file_contents = "# coding: {}\ns = u'\u00E3'\n".format(encoding)
+                file_contents = "# coding: {}\n\ns = u'ã'\n".format(encoding)
                 f.write(file_contents)
         assert SortImports(file_path=tmp_fname).output == file_contents
     finally:

--- a/test_isort.py
+++ b/test_isort.py
@@ -22,6 +22,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import codecs
+import os
+import shutil
+import tempfile
+
 from pies.overrides import *
 
 from isort.isort import SortImports
@@ -1329,3 +1334,15 @@ def test_fcntl():
                   "import sys\n")
     assert SortImports(file_contents=test_input).output == test_input
 
+
+def test_other_file_encodings():
+    try:
+        tmp_dir = tempfile.mkdtemp()
+        for encoding in ('latin1', 'utf8'):
+            tmp_fname = os.path.join(tmp_dir, 'test_{}.py'.format(encoding))
+            with codecs.open(tmp_fname, mode='w', encoding=encoding) as f:
+                file_contents = "# coding: {}'\ns = u'\u00E3'".format(encoding)
+                f.write(file_contents)
+            assert SortImports(file_path=tmp_fname).output == file_contents
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
`isort` doesn't handle different source code encodings very well - if you make a python file like 

``` 
# coding: latin1

s = u'ã'
```

Where the file is saved in latin1 encoding, it is a perfectly valid python module in both python 2 and python 3.  But unfortunately `isort`will raise an unhandled exception, because it assumes files are saved in utf8 coding.  Furthermore, `isort` will currently save all files as utf-8 encoding, *but not change the coding declaration of the source*, which is dangerous.  We should either respect the original encoding, or rewrite the coding declaration to mention that the new file is saved in utf-8.  