### PR TITLE
Fix Import Line Splitting Bug

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -30,6 +30,7 @@ import codecs
 import copy
 import itertools
 import os
+import re
 from collections import namedtuple
 from datetime import datetime
 from difflib import unified_diff
@@ -287,8 +288,9 @@ class SortImports(object):
         """
         if len(line) > self.config['line_length']:
             for splitter in ("import", "."):
-                if splitter in line and not line.strip().startswith(splitter):
-                    line_parts = line.split(splitter)
+                exp = r"\b" + re.escape(splitter) + r"\b"
+                if re.search(exp, line) and not line.strip().startswith(splitter):
+                    line_parts = re.split(exp, line)
                     next_line = []
                     while (len(line) + 2) > (self.config['wrap_length'] or self.config['line_length']) and line_parts:
                         next_line.append(line_parts.pop())

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 sources = """
 eNrcvWmXG1l2INYzY1tjeGYk2ePtg32iQVGIKCKDSXZpyylUqVRFqqmuYvFwUVPOSoGRQGRmNJER

--- a/test_isort.py
+++ b/test_isort.py
@@ -1329,3 +1329,14 @@ def test_fcntl():
                   "import sys\n")
     assert SortImports(file_contents=test_input).output == test_input
 
+def test_import_split_is_word_boundary_aware():
+
+    test_input = ("from mycompany.model.size_value_array_import_func import ("
+                "    get_size_value_array_import_func_jobs,"
+                ")")
+    test_output = SortImports(file_contents=test_input,
+      multi_line_output=WrapModes.VERTICAL_HANGING_INDENT,
+      line_length=79).output
+
+    assert test_output == ("from mycompany.model.size_value_array_import_func import \\\n"
+                           "    get_size_value_array_import_func_jobs\n")


### PR DESCRIPTION
Hi Timothy!

Thanks for creating isort! It's quite useful.

I ran into a bug when using isort to lint a file that contained an import in which the split token "import" appeared in a module's name. This resulted in the module's name being split into non-sense strings.

e.g.
```python
from mycompany.model.size_value_array_import_func import (
    get_size_value_array_import_func_jobs,
)
```
... was split into ...
```python
[u'mycompany.model.size_value_array_', u'_func ', u' get_size_value_array_', u'_func_jobs']
```
I have patched the isort _wrap() function to prevent this from happening. I ensured that all tests passed after my patch was introduced, and I added an additional test to ensure that line splitting is word boundary aware.

All the best,

-Patrick
