### PR TITLE
Add globbing support, fixes timothycrosley/isort#292

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import codecs
 import copy
+import fnmatch
 import io
 import itertools
 import os
@@ -94,10 +95,11 @@ class SortImports(object):
         self.file_path = file_path or ""
         if file_path and not file_contents:
             file_path = os.path.abspath(file_path)
-            if self._should_skip(file_path):
+            if self._should_skip(file_path) or self._should_skip_glob(file_path):
                 self.skipped = True
                 if self.config['verbose']:
-                    print("WARNING: {0} was skipped as it's listed in 'skip' setting".format(file_path))
+                    print("WARNING: {0} was skipped as it's listed in 'skip' setting"
+                          " or matches a glob in 'skip_glob' setting".format(file_path))
                 file_contents = None
             else:
                 self.file_path = file_path
@@ -201,6 +203,12 @@ class SortImports(object):
             if position[1] in self.config['skip']:
                 return True
             position = os.path.split(position[0])
+
+    def _should_skip_glob(self, filename):
+        for glob in self.config['skip_glob']:
+            if fnmatch.fnmatch(filename, glob):
+                return True
+        return False
 
     def place_module(self, moduleName):
         """Tries to determine if a module is a python std import, third party import, or project code:

--- a/isort/main.py
+++ b/isort/main.py
@@ -111,6 +111,7 @@ def create_parser():
     parser.add_argument('-s', '--skip', help='Files that sort imports should skip over.', dest='skip', action='append')
     parser.add_argument('-ns', '--dont-skip', help='Files that sort imports should never skip over.',
                         dest='not_skip', action='append')
+    parser.add_argument('-sg', '--skip-glob', help='Files that sort imports should skip over.', dest='skip_glob', action='append')
     parser.add_argument('-t', '--top', help='Force specific imports to the top of their appropriate section.',
                         dest='force_to_top', action='append')
     parser.add_argument('-f', '--future', dest='known_future_library', action='append',

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -43,6 +43,7 @@ WrapModes = namedtuple('WrapModes', WrapModes)(*range(len(WrapModes)))
 # Note that none of these lists must be complete as they are simply fallbacks for when included auto-detection fails.
 default = {'force_to_top': [],
            'skip': ['__init__.py', ],
+           'skip_glob': [],
            'line_length': 79,
            'wrap_length': 0,
            'sections': DEFAULT_SECTIONS,


### PR DESCRIPTION
This adds support for skipping based on globs. There are more details in the original issue #292 . 

Tests need to be added. I didn't see any file skipping tests in test_isort.py . What would be the proper way to add those tests, something similar to  test_other_file_encodings()?