### PR TITLE
Convert README to rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,38 @@
-![isort](https://raw.github.com/timothycrosley/isort/master/logo.png)
-=====
+.. image:: https://raw.github.com/timothycrosley/isort/master/logo.png
+    :alt: isort
 
-[![PyPI version](https://badge.fury.io/py/isort.png)](http://badge.fury.io/py/isort)
-[![PyPi downloads](https://pypip.in/d/isort/badge.png)](https://crate.io/packages/isort/)
-[![Build Status](https://travis-ci.org/timothycrosley/isort.png?branch=master)](https://travis-ci.org/timothycrosley/isort)
-[![License](https://pypip.in/license/isort/badge.png)](https://pypi.python.org/pypi/isort/)
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/timothycrosley/isort/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+########
+
+.. image:: https://badge.fury.io/py/isort.png
+    :target: http://badge.fury.io/py/isort
+    :alt: PyPI version
+
+.. image:: https://pypip.in/d/isort/badge.png
+    :target: https://crate.io/packages/isort/
+    :alt: PyPi downloads
+
+.. image:: https://travis-ci.org/timothycrosley/isort.png?branch=master
+    :target: https://travis-ci.org/timothycrosley/isort
+    :alt: Build Status
+
+.. image:: https://pypip.in/license/isort/badge.png
+    :target: https://pypi.python.org/pypi/isort/
+    :alt: License
+
+.. image:: https://d2weczhvl823v0.cloudfront.net/timothycrosley/isort/trend.png
+    :target: https://bitdeli.com/free "Bitdeli Badge"
+    :alt: Bitdeli Badge
+
 
 isort your python imports for you so you don't have to.
 
 isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections.
-It provides a command line utility, Python library and [plugins for various editors](https://github.com/timothycrosley/isort/wiki/isort-Plugins) to quickly sort all your imports.
-It currently cleanly supports Python 2.6 - 3.5 using pies (https://github.com/timothycrosley/pies) to achieve this without ugly hacks and/or py2to3.
+It provides a command line utility, Python library and `plugins for various editors <https://github.com/timothycrosley/isort/wiki/isort-Plugins>`_ to quickly sort all your imports.
+It currently cleanly supports Python 2.6 - 3.5 using `pies <https://github.com/timothycrosley/pies>`_ to achieve this without ugly hacks and/or py2to3.
 
 Before isort:
+
+.. code-block:: python
 
     from my_lib import Object
 
@@ -39,6 +58,8 @@ Before isort:
 
 After isort:
 
+.. code-block:: python
+
     from __future__ import absolute_import
 
     import os
@@ -53,65 +74,89 @@ After isort:
     print("yo")
 
 Installing isort
-===================
+================
 
 Installing isort is as simple as:
+
+.. code-block:: bash
 
     pip install isort
 
 or if you prefer
 
+.. code-block:: bash
+
     easy_install isort
 
 Using isort
-===================
+===========
 
-**from the command line**:
+**From the command line**:
+
+.. code-block:: bash
 
     isort mypythonfile.py mypythonfile2.py
 
 or recursively:
 
+.. code-block:: bash
+
     isort -rc .
 
- *which is equivalent to*
+*which is equivalent to:*
+
+.. code-block:: bash
 
     isort **/*.py
 
-or to see the proposed changes without applying them
+or to see the proposed changes without applying them:
+
+.. code-block:: bash
 
     isort mypythonfile.py --diff
 
-finally, to atomically run isort against a project, only applying changes if they don't introduce syntax errors do:
+Finally, to atomically run isort against a project, only applying changes if they don't introduce syntax errors do:
+
+.. code-block:: bash
 
     isort -rc --atomic .
 
 (Note: this is disabled by default as it keeps isort from being able to run against code written using a different version of Python)
 
-**from within Python**:
+**From within Python**:
+
+.. code-block:: bash
 
     from isort import SortImports
 
     SortImports("pythonfile.py")
 
-or
+or:
+
+.. code-block:: bash
 
     from isort import SortImports
 
     new_contents = SortImports(file_contents=old_contents).output
 
-**from within Kate**:
+**From within Kate:**
+
+.. code-block:: bash
 
     ctrl+[
 
-or
+or:
+
+.. code-block:: bash
 
     menu > Python > Sort Imports
 
 Installing isort's Kate plugin
-===================
+==============================
 
 For KDE 4.13+ / Pate 2.0+:
+
+.. code-block:: bash
 
     wget https://raw.github.com/timothycrosley/isort/master/kate_plugin/isort_plugin.py --output-document ~/.kde/share/apps/kate/pate/isort_plugin.py
     wget https://raw.github.com/timothycrosley/isort/master/kate_plugin/isort_plugin_ui.rc --output-document ~/.kde/share/apps/kate/pate/isort_plugin_ui.rc
@@ -119,29 +164,31 @@ For KDE 4.13+ / Pate 2.0+:
 
 For all older versions:
 
+.. code-block:: bash
+
     wget https://raw.github.com/timothycrosley/isort/master/kate_plugin/isort_plugin_old.py --output-document ~/.kde/share/apps/kate/pate/isort_plugin.py
 
 You will then need to restart kate and enable Python Plugins as well as the isort plugin itself.
 
 Installing isort's for your preferred text editor
-===================
+=================================================
 
 Several plugins have been written that enable to use isort from within a variety of text-editors.
-You can find a full list of them [on the isort wiki](https://github.com/timothycrosley/isort/wiki/isort-Plugins).
+You can find a full list of them `on the isort wiki <https://github.com/timothycrosley/isort/wiki/isort-Plugins>`_.
 Additionally, I will enthusiastically accept pull requests that include plugins for other text editors
 and add documentation for them as I am notified.
 
 How does isort work?
 ====================
 
-isort parses specified files for global level import lines (imports outside of try / excepts blocks, functions, etc..)
+isort parses specified files for global level import lines (imports outside of try / except blocks, functions, etc..)
 and puts them all at the top of the file grouped together by the type of import:
 
 - Future
 - Python Standard Library
 - Third Party
 - Current Python Project
-- Explicitly Local (. before import, as in: from . import x)
+- Explicitly Local (. before import, as in: ``from . import x``)
 - Custom Separate Sections (Defined by forced_separate list in configuration file)
 - Custom Sections (Defined by sections list in configuration file)
 
@@ -149,7 +196,7 @@ Inside of each section the imports are sorted alphabetically. isort automaticall
 and wraps long from imports to the specified line length (defaults to 80).
 
 When will isort not work?
-======================
+=========================
 
 If you ever have the situation where you need to have a try / except block in the middle of top-level imports or if
 your import order is directly linked to precedence.
@@ -160,12 +207,14 @@ a new settings file. In this case if any of the imports change order you are cha
 However, you can configure isort to skip over just these files - or even to force certain imports to the top.
 
 Configuring isort
-======================
+=================
 
 If you find the default isort settings do not work well for your project, isort provides several ways to adjust
 the behavior.
 
-To configure isort for a single user create a ~/.isort.cfg file:
+To configure isort for a single user create a ``~/.isort.cfg`` file:
+
+.. code-block:: ini
 
     [settings]
     line_length=120
@@ -181,10 +230,10 @@ To configure isort for a single user create a ~/.isort.cfg file:
     forced_separate=django.contrib,django.utils
     default_section=FIRSTPARTY
 
-Additionally, you can specify project level configuration simply by placing a .isort.cfg file at the root of your
+Additionally, you can specify project level configuration simply by placing a ``.isort.cfg`` file at the root of your
 project. isort will look up to 25 directories up, from the the file it is ran against, to find a project specific configuration.
 
-Or, if you prefer, you can add an isort section to your project's setup.cfg with any desired settings.
+Or, if you prefer, you can add an isort section to your project's ``setup.cfg`` with any desired settings.
 
 You can then override any of these settings by using command line arguments, or by passing in override values to the
 SortImports class.
@@ -192,23 +241,27 @@ SortImports class.
 Finally, as of version 3.0 isort supports editorconfig files using the standard syntax defined here:
 http://editorconfig.org/
 
-Meaning you place any standard isort configuration parameters within a .editorconfig file under the *.py section
+Meaning you place any standard isort configuration parameters within a .editorconfig file under the ``*.py`` section
 and they will be honored.
 
-For a full list of isort settings and their meanings [take a look at the isort wiki](https://github.com/timothycrosley/isort/wiki/isort-Settings).
+For a full list of isort settings and their meanings `take a look at the isort wiki <https://github.com/timothycrosley/isort/wiki/isort-Settings>`_.
 
 Multi line output modes
-======================
+=======================
 
 You will notice above the "multi_line_output" setting. This setting defines how from imports wrap when they extend
 past the line_length limit and has 6 possible settings:
 
-0 - Grid
+**0 - Grid**
+
+.. code-block:: python
 
     from third_party import (lib1, lib2, lib3,
                              lib4, lib5, ...)
 
-1 - Vertical
+**1 - Vertical**
+
+.. code-block:: python
 
     from third_party import (lib1,
                              lib2,
@@ -217,13 +270,17 @@ past the line_length limit and has 6 possible settings:
                              lib5,
                              ...)
 
-2 - Hanging Indent
+**2 - Hanging Indent**
+
+.. code-block:: python
 
     from third_party import \
         lib1, lib2, lib3, \
         lib4, lib5, lib6
 
-3 - Vertical Hanging Indent
+**3 - Vertical Hanging Indent**
+
+.. code-block:: python
 
     from third_party import (
         lib1,
@@ -232,21 +289,27 @@ past the line_length limit and has 6 possible settings:
         lib4,
     )
 
-4 - Hanging Grid
+**4 - Hanging Grid**
+
+.. code-block:: python
 
     from third_party import (
         lib1, lib2, lib3, lib4,
         lib5, ...)
 
-5 - Hanging Grid Grouped
+**5 - Hanging Grid Grouped**
+
+.. code-block:: python
 
     from third_party import (
         lib1, lib2, lib3, lib4,
         lib5, ...
     )
 
-Alternatively, you can set force_single_line to True (-sl on the command line) and every import will appear on its
-own line
+Alternatively, you can set ``force_single_line`` to ``True`` (``-sl`` on the command line) and every import will appear on its
+own line:
+
+.. code-block:: python
 
     from third_party import lib1
     from third_party import lib2
@@ -260,16 +323,18 @@ Note: to change the how constant indents appear - simply change the indent prope
 
 For example:
 
+.. code-block:: python
+
     "    "
 
-is equivalent to 4
+is equivalent to 4.
 
 For the import styles that use parentheses, you can control whether or not to
-include a trailing comma after the last import with the include_trailing_comma
-option (defaults to false).
+include a trailing comma after the last import with the ``include_trailing_comma``
+option (defaults to ``False``).
 
 Intelligently Balanced Multi-line Imports
-======================
+=========================================
 
 As of isort 3.1.0 support for balanced multi-line imports has been added.
 With this enabled isort will dynamically change the import length to the one that produces the most balanced grid,
@@ -277,30 +342,40 @@ while staying below the maximum import length defined.
 
 Example:
 
+.. code-block:: python
+
     from __future__ import (absolute_import, division,
                             print_function, unicode_literals)
 
 Will be produced instead of:
 
+.. code-block:: python
+
     from __future__ import (absolute_import, division, print_function,
                             unicode_literals)
 
-To enable this set 'balanced_wrapping' to True in your config or pass the -e option into the command line utility.
+To enable this set ``balanced_wrapping`` to ``True`` in your config or pass the ``-e`` option into the command line utility.
 
 Custom Sections and Ordering
 ============================
 
-You can change the section order with `sections` option from the default of:
+You can change the section order with ``sections`` option from the default of:
+
+.. code-block:: ini
 
     FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 to your preference:
+
+.. code-block:: ini
 
     sections=FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
 
 You also can define your own sections and thier order.
 
 Example:
+
+.. code-block:: ini
 
     known_django=django
     known_pandas=pandas,numpy
@@ -309,18 +384,22 @@ Example:
 would create two new sections with the specified known modules.
 
 Auto-comment import sections
-======================
+============================
 
 Some projects prefer to have import sections uniquely titled to aid in identifying the sections quickly
-when visually scanning. isort can automate this as well. To do this simply set the import_heading_{section_name}
+when visually scanning. isort can automate this as well. To do this simply set the ``import_heading_{section_name}``
 setting for each section you wish to have auto commented - to the desired comment.
 
 For Example:
+
+.. code-block:: ini
 
     import_heading_stdlib=Standard Library
     import_heading_firstparty=My Stuff
 
 Would lead to output looking like the following:
+
+.. code-block:: python
 
     # Standard Library
     import os
@@ -332,10 +411,12 @@ Would lead to output looking like the following:
     import myproject.test
 
 Ordering by import length
-======================
+=========================
 
-isort also makes it easy to sort your imports by length, simply by setting the length_sort option to True.
+isort also makes it easy to sort your imports by length, simply by setting the ``length_sort`` option to ``True``.
 This will result in the following output style:
+
+.. code-block:: python
 
     from evn.util import (
         Pool,
@@ -347,19 +428,25 @@ This will result in the following output style:
     )
 
 Skip processing of imports (outside of configuration)
-======================
+=====================================================
 
-To make isort ignore a single import simply add a comment at the end of the import line containing the text 'isort:skip'
+To make isort ignore a single import simply add a comment at the end of the import line containing the text ``isort:skip``:
+
+.. code-block:: python
 
     import module  # isort:skip
 
-or
+or:
+
+.. code-block:: python
 
     from xyz import (abc,  # isort:skip
                      yo,
                      hey)
 
-To make isort skip an entire file simply add the following to the modules doc string: 'isort:skip_file'
+To make isort skip an entire file simply add ``isort:skip_file`` to the module's doc string:
+
+.. code-block:: python
 
     """ my_module.py
         Best module ever
@@ -371,48 +458,62 @@ To make isort skip an entire file simply add the following to the modules doc st
     import a
 
 Adding an import to multiple files
-======================
+==================================
 
 isort makes it easy to add an import statement across multiple files, while being assured it's correctly placed.
 
-from the command line:
+From the command line:
+
+.. code-block:: bash
 
     isort -a "from __future__ import print_function" *.py
 
 from within Kate:
 
+.. code-block::
+
     ctrl+]
 
 or:
 
+.. code-block::
+
     menu > Python > Add Import
 
 Removing an import from multiple files
-======================
+======================================
 
-isort makes it easy to remove an import from multiple files, without having to be concerned with how it was originally
-formatted
+isort also makes it easy to remove an import from multiple files, without having to be concerned with how it was originally
+formatted.
 
-from the command line:
+From the command line:
+
+.. code-block:: bash
 
     isort -r "os.system" *.py
 
 from within Kate:
 
+.. code-block::
+
     ctrl+shift+]
 
 or:
+
+.. code-block::
 
     menu > Python > Remove Import
 
 Using isort to verify code
 ==========================
 
-The ```--check-only``` option
------------------------------
+The ``--check-only`` option
+---------------------------
 
-isort can also be used to used to verify that code is correctly formatted by running it with -c.
-Any files that contain incorrectly sorted imports will be outputted to stderr.
+isort can also be used to used to verify that code is correctly formatted by running it with ``-c``.
+Any files that contain incorrectly sorted imports will be outputted to ``stderr``.
+
+.. code-block:: bash
 
     isort **/*.py -c -vb
 
@@ -423,7 +524,7 @@ One great place this can be used is with a pre-commit git hook, such as this one
 
 https://gist.github.com/acdha/8717683
 
-Which can help to ensure a certain level of code quality throughout a project.
+This can help to ensure a certain level of code quality throughout a project.
 
 
 Git hook
@@ -433,30 +534,36 @@ isort provides a hook function that can be integrated into your Git pre-commit s
 Python code before committing.
 
 To cause the commit to fail if there are isort errors (strict mode), include the following in
-`.git/hooks/pre-commit`:
+``.git/hooks/pre-commit``:
+
+.. code-block:: python
 
     from isort.hooks import git_hook
 
     if __name__ == '__main__':
         sys.exit(git_hook(strict=True))
 
-If you just want to display warnings, but allow the commit to happen anyway, call git_hook without
+If you just want to display warnings, but allow the commit to happen anyway, call ``git_hook`` without
 the `strict` parameter.
 
 Setuptools integration
 ----------------------
 
-Upon installation, isort enables a setuptools command that checks Python files
+Upon installation, isort enables a ``setuptools`` command that checks Python files
 declared by your project.
 
 Running ``python setup.py isort`` on the command line will check the files
 listed in your ``py_modules`` and ``packages``.  If any warning is found,
-the command will exit with an error code::
+the command will exit with an error code:
+
+.. code-block:: bash
 
     $ python setup.py isort
 
 Also, to allow users to be able to use the command without having to install
-isort themselves, add isort to the setup_requires of your setup() like so::
+isort themselves, add isort to the setup_requires of your ``setup()`` like so:
+
+.. code-block:: python
 
     setup(
         name="project",
@@ -468,9 +575,8 @@ isort themselves, add isort to the setup_requires of your setup() like so::
     )
 
 
-
 Why isort?
-======================
+==========
 
 isort simply stands for import sort. It was originally called "sortImports" however I got tired of typing the extra
 characters and came to the realization camelCase is not pythonic.

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,8 @@ except ImportError:
         def run(self):
             raise SystemExit(subprocess.call([sys.executable, 'runtests.py']))
 
-try:
-   import pypandoc
-   readme = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError, OSError, RuntimeError):
-   readme = ''
+with open('README.rst', 'r') as f:
+   readme = f.read()
 
 setup(name='isort',
       version='4.0.0',


### PR DESCRIPTION
Resolves #301 . Looks a bit better to me since `ini`/`python`/`bash` highlighting is specified :)

You can preview on https://github.com/adamchainz/isort/tree/readme_rst . The command `python setup.py check --restructuredtext` passes which implies it will look fine when uploaded to PyPI.