### PR TITLE
Project root directory settings for git_hook

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -58,7 +58,7 @@ class SortImports(object):
     def __init__(self, file_path=None, file_contents=None, write_to_stdout=False, check=False,
                  show_diff=False, settings_path=None, **setting_overrides):
 
-        if not settings_path and file_path:
+        if not settings_path and not file_contents and file_path:
             settings_path = os.path.dirname(os.path.abspath(file_path))
         settings_path = settings_path or os.getcwd()
 


### PR DESCRIPTION
When using the git_hook, it searches the settings on every base folder path of the files commited instead of keeping the settings of the root folder.

This fix provides a way that during a git commit, the git_hook search only in the root folder where the command has been run.

Let me know if I'm doing something wrong.