### PR TITLE
skip files even when file_contents is provided

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -93,7 +93,7 @@ class SortImports(object):
         self.file_encoding = 'utf-8'
         file_name = file_path
         self.file_path = file_path or ""
-        if file_path and not file_contents:
+        if file_path:
             file_path = os.path.abspath(file_path)
             if self._should_skip(file_path) or self._should_skip_glob(file_path):
                 self.skipped = True
@@ -101,7 +101,7 @@ class SortImports(object):
                     print("WARNING: {0} was skipped as it's listed in 'skip' setting"
                           " or matches a glob in 'skip_glob' setting".format(file_path))
                 file_contents = None
-            else:
+            elif not file_contents:
                 self.file_path = file_path
                 self.file_encoding = coding_check(file_path)
                 with codecs.open(file_path, encoding=self.file_encoding) as file_to_import_sort:

--- a/test_isort.py
+++ b/test_isort.py
@@ -446,6 +446,16 @@ def test_skip():
                            "import sys  # isort:skip this import needs to be placed here\n")
 
 
+def test_skip_with_file_name():
+    """Ensure skipping a file works even when file_contents is provided."""
+    test_input = ("import django\n"
+                  "import myproject\n")
+
+    skipped = SortImports(file_path='/baz.py', file_contents=test_input, known_third_party=['django'],
+                          skip=['baz.py']).skipped
+    assert skipped
+
+
 def test_force_to_top():
     """Ensure forcing a single import to the top of its category works as expected."""
     test_input = ("import lib6\n"


### PR DESCRIPTION
git hooks provide both file_path and file_contents. Previously,
should_skip only checked if file_path was provided without
file_contents. This introduced a situation where the isort git hook
would fail on files that isort wouldn't touch.

Related PR: https://github.com/timothycrosley/isort/pull/218