### PR TITLE
Fix compatibility with Python 3.5

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -180,8 +180,8 @@ class SortImports(object):
             self.output.splitlines(1),
             fromfile=self.file_path + ':before',
             tofile=self.file_path + ':after',
-            fromfiledate=datetime.fromtimestamp(os.path.getmtime(self.file_path)),
-            tofiledate=datetime.now()
+            fromfiledate=str(datetime.fromtimestamp(os.path.getmtime(self.file_path))),
+            tofiledate=str(datetime.now())
         ):
             stdout.write(line)
 


### PR DESCRIPTION
Difflib in py3.5 checks the variable types passed in to unified_diff -
as such it would break saying they aren't strings. Previous Python
versions would just call str() on them rather than checking. This just
adds the str() check and will subsequently fix the issue and still work
on previous Python versions.