### PR TITLE
Allow imports to be sorted by module, independant of import_type

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -480,6 +480,13 @@ class SortImports(object):
                     self._add_straight_imports(straight_modules, section, section_output)
                     self._add_from_imports(from_modules, section, section_output)
 
+                if self.config.get('force_sort_within_sections', False):
+                    def by_module(line):
+                        line = re.sub('^from ', '', line)
+                        line = re.sub('^import ', '', line)
+                        return line
+                    section_output.sort(key=by_module)
+
                 if section_output:
                     section_name = section
                     if section_name in self.place_imports:


### PR DESCRIPTION
Allows sorting by module within sections like:

```python
import a
from b import c
import d
```

This is to support how my employer does it.