### PR TITLE
Pylama expects a iterable to be returned.

### DIFF
--- a/isort/pylama_isort.py
+++ b/isort/pylama_isort.py
@@ -25,3 +25,5 @@ class Linter(BaseLinter):
                     'text': 'Incorrectly sorted imports.',
                     'type': 'ISORT'
                 }]
+            else:
+                return []


### PR DESCRIPTION
    # pylama . -v
    [.....]
    Run isort {}
    Traceback (most recent call last):
      File "/.../lib/python3.4/site-packages/pylama/core.py", line 65, in run
        select=params.get("select", set()), params=lparams):
    TypeError: 'NoneType' object is not iterable
