### PR TITLE
Add default value to config settings

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -94,7 +94,12 @@ default = {'force_to_top': [],
            'include_trailing_comma': False,
            'from_first': False,
            'verbose': False,
-           'quiet': False}
+           'quiet': False,
+           'force_adds': False,
+           'force_alphabetical_sort': False,
+           'force_grid_wrap': False,
+           'force_sort_within_sections': False,
+           'show_diff': False}
 
 
 @lru_cache()


### PR DESCRIPTION
These default settings are required because `_update_with_config_file`
convert the value from config file to an existing value type. The existing
value type is determined from the value of the `access_key` in the
`default` dict.