### PR TITLE
Use default_section instead of FIRSTPARTY as fallback for existing paths

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -243,7 +243,7 @@ class SortImports(object):
                 elif "python2" in prefix.lower() or "python3" in prefix.lower():
                     return self.sections.STDLIB
                 else:
-                    return self.sections.FIRSTPARTY
+                    return self.config['default_section']
 
         return self.config['default_section']
 


### PR DESCRIPTION
If you `pip install -e` a requirement it is considered to be first-party
always.

This makes sense for the typical `pip install -e .`, but not when
installing requirements editable through Git, where it appears to be
useful in case you want to hack on it.

I've tried adding the following to `place_module`, but it also catches
the `pip install -e .` case.  This could then be worked around by adding
it to `known_first_party`, but then it might also be an option to have a
mode where only explicitly defined packages are considered to be
first-party?!

```
elif os.path.exists(os.path.join(prefix, os.path.basename(prefix).replace('-', '_') + '.egg-info')):
    return self.sections.THIRDPARTY
```

With this change the following config will work as expected:

    known_first_party = myproject
    default_section = THIRDPARTY