### PR TITLE
Allow specifying virtual env directory

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -227,7 +227,7 @@ class SortImports(object):
                     return placement
 
         paths = PYTHONPATH
-        virtual_env = os.environ.get('VIRTUAL_ENV', None)
+        virtual_env = self.config.get('virtual_env') or os.environ.get('VIRTUAL_ENV')
         if virtual_env:
             paths = list(paths)
             for version in ((2, 6), (2, 7), (3, 0), (3, 1), (3, 2), (3, 3), (3, 4)):


### PR DESCRIPTION
This is helpful for running [pre-commit](https://github.com/pre-commit/pre-commit) hooks since they run in their own virtual environment where `isort` fails to correctly infer whether a package is third-party or not, since no packages are installed there.