### PR TITLE
Fix 'not_skip' not ignoring working, when there is a more specific filepath in the skip list

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -61,18 +61,18 @@ def iter_source_code(paths, config, skipped):
     """Iterate over all Python source files defined in paths."""
     for path in paths:
         if os.path.isdir(path):
-            if should_skip(path, config):
+            if should_skip(path, config, os.getcwd()):
                 skipped.append(path)
                 continue
 
             for dirpath, dirnames, filenames in os.walk(path, topdown=True):
                 for dirname in list(dirnames):
-                    if should_skip(dirname, config):
+                    if should_skip(dirname, config, dirpath):
                         skipped.append(dirname)
                         dirnames.remove(dirname)
                 for filename in filenames:
                     if filename.endswith('.py'):
-                        if should_skip(filename, config):
+                        if should_skip(filename, config, dirpath):
                             skipped.append(filename)
                         else:
                             yield os.path.join(dirpath, filename)

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -198,10 +198,10 @@ def _get_config_data(file_path, sections):
     return {}
 
 
-def should_skip(filename, config):
+def should_skip(filename, config, path='/'):
     """Returns True if the file should be skipped based on the passed in settings."""
     for skip_path in config['skip']:
-        if skip_path.endswith(filename):
+        if os.path.join(path, filename).endswith(skip_path):
             return True
 
     position = os.path.split(filename)


### PR DESCRIPTION

This would occur when not_skip is applied to `__init__.py`, and skip has a file like `some/module/__init__.py`. This meant that all `__init__.py` files were skipped