### PR TITLE
Fix `--diff` with stdin

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -191,7 +191,8 @@ class SortImports(object):
             self.output.splitlines(1),
             fromfile=self.file_path + ':before',
             tofile=self.file_path + ':after',
-            fromfiledate=str(datetime.fromtimestamp(os.path.getmtime(self.file_path))),
+            fromfiledate=str(datetime.fromtimestamp(os.path.getmtime(self.file_path))
+                             if self.file_path else datetime.now()),
             tofiledate=str(datetime.now())
         ):
             stdout.write(line)


### PR DESCRIPTION
This fixes the following error with `isort --diff -`:

    Traceback (most recent call last):
      File "…/pyenv/project/bin/isort", line 9, in <module>
        load_entry_point('isort', 'console_scripts', 'isort')()
      File "…/isort/isort/main.py", line 239, in main
        SortImports(file_contents=sys.stdin.read(), write_to_stdout=True, **arguments)
      File "…/isort/isort/isort.py", line 170, in __init__
        self._show_diff(file_contents)
      File "…/isort/isort/isort.py", line 194, in _show_diff
        fromfiledate=str(datetime.fromtimestamp(os.path.getmtime(self.file_path))),
      File "…/pyenv/project/lib/python3.5/genericpath.py", line 55, in getmtime
        return os.stat(filename).st_mtime
    FileNotFoundError: [Errno 2] No such file or directory: ''