### PR TITLE
Fix multiline sorting with force-alphabetical-sort

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -1494,22 +1494,33 @@ def test_comment_at_top_of_file():
 
 def test_alphabetic_sorting():
     """Test to ensure isort correctly handles top of file comments"""
-    test_input = ("from django.contrib.gis.geos import GEOSException\n"
+    test_input = ("import unittest\n"
+                  "\n"
+                  "import ABC\n"
+                  "import Zope\n"
+                  "from django.contrib.gis.geos import GEOSException\n"
                   "from plone.app.testing import getRoles\n"
                   "from plone.app.testing import ManageRoles\n"
                   "from plone.app.testing import setRoles\n"
                   "from Products.CMFPlone import utils\n"
-                  "\n"
-                  "import ABC\n"
-                  "import unittest\n"
-                  "import Zope\n")
+                  )
     options = {'force_single_line': True,
                'force_alphabetical_sort': True, }
-    assert SortImports(file_contents=test_input, **options).output == test_input
+
+    output = SortImports(file_contents=test_input, **options).output
+    assert output == test_input
 
     test_input = ("# -*- coding: utf-8 -*-\n"
                   "from django.db import models\n")
     assert SortImports(file_contents=test_input).output == test_input
+
+
+def test_alphabetic_sorting_multi_line():
+    """Test to ensure isort correctly handles multiline import see: issue 364"""
+    test_input = ("from a import (CONSTANT_A, cONSTANT_B, CONSTANT_C, CONSTANT_D, CONSTANT_E,\n"
+                  "               CONSTANT_F, CONSTANT_G, CONSTANT_H, CONSTANT_I, CONSTANT_J)\n")
+    options = {'force_alphabetical_sort': True, }
+    assert SortImports(file_contents=test_input, **options).output == test_input
 
 
 def test_comments_not_duplicated():
@@ -1596,10 +1607,10 @@ def test_alphabetic_sorting_no_newlines():
     test_output = SortImports(file_contents=test_input,force_alphabetical_sort=True).output
     assert test_input == test_output
 
-    test_input = ('from a import b\n'
-                  '\n'
-                  'import os\n'
+    test_input = ('import os\n'
                   'import unittest\n'
+                  '\n'
+                  'from a import b\n'
                   '\n'
                   '\n'
                   'print(1)\n')


### PR DESCRIPTION
Raised in https://github.com/timothycrosley/isort/issues/364

The separate code for --force-alphabetical-sort has been removed and
a boolean flag added to handle sorting with or without case in the
_module_key function (which handles the sorting).

Note this commit alters these 2 tests:
test_alphabetic_sorting_no_newlines, test_alphabetic_sorting
This results in the lone imports being moved to the top of the file.
I think this is better as it means the force_alphabetical_sort tests
now behave similarly to the other tests in the file.

Please advise if it is ok to change the tests like this. 

The big red commit in isort.py is because lines 444 -> 468 were removed and the 
if statement was removed