### PR TITLE
Add support for globbing in forced_separate

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -36,6 +36,7 @@ import sys
 from collections import namedtuple
 from datetime import datetime
 from difflib import unified_diff
+from fnmatch import fnmatch
 from glob import glob
 from sys import path as PYTHONPATH
 from sys import stdout
@@ -212,7 +213,12 @@ class SortImports(object):
 
         """
         for forced_separate in self.config['forced_separate']:
-            if moduleName.startswith(forced_separate) or moduleName.startswith("." + forced_separate):
+            # Ensure all forced_separate patterns will match to end of string
+            pathGlob = forced_separate
+            if not forced_separate.endswith('*'):
+                pathGlob = '%s*' % forced_separate
+
+            if fnmatch(moduleName, pathGlob) or fnmatch(moduleName, '.' + pathGlob):
                 return forced_separate
 
         if moduleName.startswith("."):

--- a/test_isort.py
+++ b/test_isort.py
@@ -1648,3 +1648,25 @@ def test_lines_between_sections():
                                                                                       'from bar import baz\n')
     assert SortImports(file_contents=test_input, lines_between_sections=2).output == ('import os\n\n\n'
                                                                                       'from bar import baz\n')
+
+def test_forced_sepatate_globs():
+    """Test to ensure that forced_separate glob matches lines"""
+    test_input = ('import os\n'
+                  '\n'
+                  'from myproject.foo.models import Foo\n'
+                  '\n'
+                  'from myproject.utils import util_method\n'
+                  '\n'
+                  'from myproject.bar.models import Bar\n'
+                  '\n'
+                  'import sys\n')
+    test_output = SortImports(file_contents=test_input, forced_separate=['*.models'],
+                              line_length=120).output
+
+    assert test_output == ('import os\n'
+                          'import sys\n'
+                          '\n'
+                          'from myproject.utils import util_method\n'
+                          '\n'
+                          'from myproject.bar.models import Bar\n'
+                          'from myproject.foo.models import Foo\n')


### PR DESCRIPTION
Addresses https://github.com/timothycrosley/isort/issues/399

This uses `fnmatch` to provide globbing to the `forced_separate` options. This allows things like "all Django models", for example, to be separated into another section.

The current limitation of this is that it does not apply to local imports. Unfortunately, adding this looks like much more work, so I'm inclined to leave the change at this.