### PR TITLE
Imports added incorrectly in function with docstring

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -1751,3 +1751,16 @@ def test_import_by_paren_issue_375():
                   '   Bar,\n'
                   ')\n')
     assert SortImports(file_contents=test_input).output == 'from .models import Bar, Foo\n'
+
+
+def test_function_with_docstring():
+    add_imports = ['from __future__ import unicode_literals']
+    test_input = ('def foo():\n'
+                  '    """ Single line triple quoted doctring """\n'
+                  '    pass\n')
+    expected_output = ('from __future__ import unicode_literals\n'
+                       '\n'
+                       'def foo():\n'
+                       '    """ Single line triple quoted doctring """\n'
+                       '    pass\n')
+    assert SortImports(file_contents=test_input, add_imports=add_imports).output == expected_output


### PR DESCRIPTION
If running `isort -a "from __future__ import unicode_literals" file.py`, where `file.py` consists of a function like:

```python
def foo():
    """ Single line triple quoted doctring """
    pass
```

`isort` incorrectly adds the import like so:

```python
def foo():
    """ Single line triple quoted doctring """
from __future__ import unicode_literals

    pass
```

Which is a syntax error. I've written a failing test for this case in this PR, although I am unsure where to start looking to fix it.