### PR TITLE
Fix hanging imports being removed

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -776,7 +776,7 @@ class SortImports(object):
                         if import_string.strip().endswith(" import") or line.strip().startswith("import "):
                             import_string += "\n" + line
                         else:
-                            import_string = import_string.rstrip().rstrip("\\") + line.lstrip()
+                            import_string = import_string.rstrip().rstrip("\\") + " " + line.lstrip()
 
                 if import_type == "from":
                     import_string = import_string.replace("import(", "import (")

--- a/test_isort.py
+++ b/test_isort.py
@@ -827,6 +827,20 @@ def test_multiline_import():
     assert SortImports(file_contents=test_input, **custom_configuration).output == expected_output
 
 
+def test_single_multiline():
+    """Test the case where a single import spawns multiple lines."""
+    test_input = ("from os import\\\n"
+                  "        getuid\n"
+                  "\n"
+                  "print getuid()\n")
+    output = SortImports(file_contents=test_input).output
+    assert output == (
+        "from os import getuid\n"
+        "\n"
+        "print getuid()\n"
+    )
+
+
 def test_atomic_mode():
     # without syntax error, everything works OK
     test_input = ("from b import d, c\n"


### PR DESCRIPTION
As mentioned in https://github.com/timothycrosley/isort/issues/425
This fixes hanging imports being removed by isort.

Code was missing a whitespace when glueing the import line together