### PR TITLE
fix settings in .isort.cfg not work

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -245,6 +245,10 @@ def main():
         print(INTRO)
         return
 
+    if 'settings_path' in arguments:
+        sp = arguments['settings_path']
+        arguments['settings_path'] = os.path.abspath(sp) if os.path.isdir(sp) else os.path.dirname(os.path.abspath(sp))
+
     file_names = arguments.pop('files', [])
     if file_names == ['-']:
         SortImports(file_contents=sys.stdin.read(), write_to_stdout=True, **arguments)


### PR DESCRIPTION
## .isort.cfg
```
# See the menu of settings available here:
#   https://github.com/timothycrosley/isort/wiki/isort-Settings

[settings]
indent='    '
line_length=200
lines_after_imports=2
skip=migrations
```

## isort.sh
```
#!/bin/bash

isort -rc -sp .isort.cfg .
```

Command above doesn't work.
Below show the commands which work and not work.

```
#!/bin/bash

isort -rc .  # work
isort -rc -sp . .  # work
isort -rc -sp .isort.cfg .  # not work
isort -rc -sp ./.isort.cfg .  # work
```

## optional arguments
```
-sp SETTINGS_PATH, --settings-path SETTINGS_PATH
                        Explicitly set the settings path instead of auto
                        determining based on file location.
``` 

As description in ``isort -h``. You maybe just want user to use PATH of ``.isort.cfg`` as argument.
But once user use command ``isort -rc -sp .isort.cfg .``. He will feel this is a bug.
And spend a lot of time to search for the right usage.