### PR TITLE
Add failing test case for issue 432

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -1796,3 +1796,18 @@ def test_plone_style():
     options = {'force_single_line': True,
                'force_alphabetical_sort': True}
     assert SortImports(file_contents=test_input, **options).output == test_input
+
+
+def test_import_inside_class_issue_432():
+    """Test to ensure issue 432 is resolved and isort doesn't insert imports in the middle of classes"""
+    test_input = ("# coding=utf-8\n"
+                  "class Foo:\n"
+                  "    def bar(self):\n"
+                  "        pass\n")
+    expected_output = ("# coding=utf-8\n"
+                       "import baz\n"
+                       "\n"
+                       "class Foo:\n"
+                       "    def bar(self):\n"
+                       "        pass\n")
+    assert SortImports(file_contents=test_input, add_imports=['import baz']).output == expected_output


### PR DESCRIPTION
I've tried to fix it but it seems to be rather tricky and related to a kind of off-by-one error between `self.index` and `output_at` that only occurs when there are no blank lines between the encoding comment and the first piece of code in the module.

For #432.
