### PR TITLE
Show diff only once

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -175,8 +175,6 @@ class SortImports(object):
 
             print("ERROR: {0} Imports are incorrectly sorted.".format(self.file_path))
             self.incorrectly_sorted = True
-            if show_diff or self.config.get('show_diff', False) is True:
-                self._show_diff(file_contents)
 
         if show_diff or self.config.get('show_diff', False) is True:
             self._show_diff(file_contents)


### PR DESCRIPTION
As you can nicely see in the diff, the condition

``` python
if show_diff or self.config.get('show_diff', False) is True:
```

exists twice and results in printing the diff twice if there are any differences. Remove one of them.
