### PR TITLE
Use a copy of sys.path

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -37,7 +37,6 @@ from datetime import datetime
 from difflib import unified_diff
 from fnmatch import fnmatch
 from glob import glob
-from sys import path as PYTHONPATH
 
 from . import settings
 from .natural import nsorted
@@ -242,7 +241,11 @@ class SortImports(object):
                 if module_name_to_check in self.config.get(config_key, []):
                     return placement
 
-        paths = PYTHONPATH
+        # Use a copy of sys.path to avoid any unintended modifications
+        # to it - e.g. `+=` used below will change paths in place and
+        # if not copied, consequently sys.path, which will grow unbounded
+        # with duplicates on every call to this method.
+        paths = list(sys.path)
         virtual_env = self.config.get('virtual_env') or os.environ.get('VIRTUAL_ENV')
         virtual_env_src = False
         if virtual_env:

--- a/test_isort.py
+++ b/test_isort.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import codecs
 import os
 import shutil
+import sys
 import tempfile
 
 from isort.isort import exists_case_sensitive, SortImports
@@ -1912,3 +1913,17 @@ def test_exists_case_sensitive_directory(tmpdir):
     tmpdir.join('pkg').ensure(dir=1)
     assert exists_case_sensitive(str(tmpdir.join('pkg')))
     assert not exists_case_sensitive(str(tmpdir.join('PKG')))
+
+
+def test_sys_path_mutation():
+    """Test to ensure sys.path is not modified"""
+    try:
+        tmp_dir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(tmp_dir, 'src', 'a'))
+        test_input = "from myproject import test"
+        options = {'virtual_env': tmp_dir}
+        expected_length = len(sys.path)
+        SortImports(file_contents=test_input, **options).output
+        assert len(sys.path) == expected_length
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
On a 1300 file project at my company, this change reduces the run-time from 11 minutes down to 5 seconds, a 130x improvement.
