### PR TITLE
Fix issue #445: Applying 'use_parentheses' should depend on 'multi_line_output' and 'include_trailing_comma'

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -334,7 +334,14 @@ class SortImports(object):
 
                     cont_line = self._wrap(self.config['indent'] + splitter.join(next_line).lstrip())
                     if self.config['use_parentheses']:
-                        return "{0}{1} (\n{2})".format(line, splitter, cont_line)
+                        return "{0}{1} (\n{2}{3}{4})".format(
+                            line, splitter, cont_line,
+                            "," if self.config['include_trailing_comma'] else "",
+                            "\n" if wrap_mode in (
+                                settings.WrapModes.VERTICAL_HANGING_INDENT,
+                                settings.WrapModes.VERTICAL_GRID_GROUPED,
+                            ) else ""
+                        )
                     return "{0}{1} \\\n{2}".format(line, splitter, cont_line)
         elif len(line) > self.config['line_length'] and wrap_mode == settings.WrapModes.NOQA:
             if "# NOQA" not in line:

--- a/test_isort.py
+++ b/test_isort.py
@@ -432,14 +432,48 @@ def test_custom_indent():
 
 def test_use_parentheses():
     test_input = (
-        "from fooooooooooooooooooooooooo.baaaaaaaaaaaaaaaaaaarrrrrrr import \\"
+        "from fooooooooooooooooooooooooo.baaaaaaaaaaaaaaaaaaarrrrrrr import "
         "    my_custom_function as my_special_function"
     )
     test_output = SortImports(
-        file_contents=test_input, known_third_party=['django'],
-        line_length=79, use_parentheses=True,
+        file_contents=test_input, line_length=79, use_parentheses=True
     ).output
-    assert '(' in test_output
+
+    assert test_output == (
+        "from fooooooooooooooooooooooooo.baaaaaaaaaaaaaaaaaaarrrrrrr import (\n"
+        "    my_custom_function as my_special_function)\n"
+    )
+
+    test_output = SortImports(
+        file_contents=test_input, line_length=79, use_parentheses=True,
+        include_trailing_comma=True,
+    ).output
+
+    assert test_output == (
+        "from fooooooooooooooooooooooooo.baaaaaaaaaaaaaaaaaaarrrrrrr import (\n"
+        "    my_custom_function as my_special_function,)\n"
+    )
+
+    test_output = SortImports(
+        file_contents=test_input, line_length=79, use_parentheses=True,
+        multi_line_output=WrapModes.VERTICAL_HANGING_INDENT
+    ).output
+
+    assert test_output == (
+        "from fooooooooooooooooooooooooo.baaaaaaaaaaaaaaaaaaarrrrrrr import (\n"
+        "    my_custom_function as my_special_function\n)\n"
+    )
+
+    test_output = SortImports(
+        file_contents=test_input, line_length=79, use_parentheses=True,
+        multi_line_output=WrapModes.VERTICAL_GRID_GROUPED,
+        include_trailing_comma=True
+    ).output
+
+    assert test_output == (
+        "from fooooooooooooooooooooooooo.baaaaaaaaaaaaaaaaaaarrrrrrr import (\n"
+        "    my_custom_function as my_special_function,\n)\n"
+    )
 
 
 def test_skip():


### PR DESCRIPTION
For example:
1. multi_line_output = 0, 1 or 2; include_trailing_comma = true
   from third_party import (
   long_name_of_the_library,)
2. multi_line_output = 3 or 5; include_trailing_comma = true
   from third_party import (
   long_name_of_the_library,
   )
3. multi_line_output = 0, 1 or 2; include_trailing_comma = false
   from third_party import (
   long_name_of_the_library)
4. multi_line_output = 3 or 5; include_trailing_comma = false
   from third_party import (
   long_name_of_the_library
   ) 
