### PR TITLE
Fix multiline comments being moved

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -862,8 +862,7 @@ class SortImports(object):
                                    and not 'isort:imports-' in last):
                                 self.comments['above']['straight'].setdefault(module, []).insert(0,
                                                                                                  self.out_lines.pop(-1))
-                                if len(self.out_lines) > max(self.import_index - 1, self._first_comment_index_end,
-                                                             1) - 1:
+                                if len(self.out_lines) > 0:
                                     last = self.out_lines[-1].rstrip()
                                 else:
                                     last = ""

--- a/test_isort.py
+++ b/test_isort.py
@@ -1767,6 +1767,18 @@ def test_import_by_paren_issue_375():
     assert SortImports(file_contents=test_input).output == 'from .models import Bar, Foo\n'
 
 
+def test_import_by_paren_issue_460():
+    """Test to ensure isort can doesnt move comments around """
+    test_input = """
+# First comment
+# Second comment
+# third comment
+import io
+import os
+"""
+    assert SortImports(file_contents=(test_input)).output == test_input
+
+
 def test_function_with_docstring():
     """Test to ensure isort can correctly sort imports when the first found content is a function with a docstring"""
     add_imports = ['from __future__ import unicode_literals']


### PR DESCRIPTION
Fix issue reported here: https://github.com/timothycrosley/isort/issues/460

Multiline comments were being moved into the wrong place.

Test added.

***_Please Note**_*
isort.py  line: 865 was changed in commit: f157b06 and I do not see
why the more complex comparison was needed so it has been removed. Please reread the original commit before accepting this merge request.
