### PR TITLE
switch force-grid-wrap to an integer value (#476)

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -427,7 +427,8 @@ class SortImports(object):
 
                     do_multiline_reformat = False
 
-                    if self.config.get('force_grid_wrap') and len(from_imports) > 1:
+                    force_grid_wrap = self.config.get('force_grid_wrap')
+                    if force_grid_wrap and len(from_imports) >= force_grid_wrap:
                         do_multiline_reformat = True
 
                     if len(import_statement) > self.config['line_length'] and len(from_imports) > 1:

--- a/isort/main.py
+++ b/isort/main.py
@@ -224,8 +224,9 @@ def create_parser():
                         help="Switches the typical ordering preference, showing from imports first then straight ones.")
     parser.add_argument('-wl', '--wrap-length', dest='wrap_length',
                         help="Specifies how long lines that are wrapped should be, if not set line_length is used.")
-    parser.add_argument('-fgw', '--force-grid-wrap',  action='store_true', dest="force_grid_wrap",
-                        help='Force from imports to be grid wrapped regardless of line length')
+    parser.add_argument('-fgw', '--force-grid-wrap', nargs='?', const=2, type=int, dest="force_grid_wrap",
+                        help='Force number of from imports (defaults to 2) to be grid wrapped regardless of line '
+                             'length')
     parser.add_argument('-fass', '--force-alphabetical-sort-within-sections',  action='store_true',
                         dest="force_alphabetical_sort", help='Force all imports to be sorted alphabetically within a '
                                                              'section')

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -101,7 +101,7 @@ default = {'force_to_top': [],
            'force_adds': False,
            'force_alphabetical_sort_within_sections': False,
            'force_alphabetical_sort': False,
-           'force_grid_wrap': False,
+           'force_grid_wrap': 0,
            'force_sort_within_sections': False,
            'show_diff': False,
            'enforce_white_space': False}
@@ -170,6 +170,13 @@ def _update_with_config_file(file_path, sections, computed_settings):
             computed_settings[access_key] = False
         elif key.startswith('known_'):
             computed_settings[access_key] = list(_as_list(value))
+        elif key == 'force_grid_wrap':
+            try:
+                result = existing_value_type(value)
+            except ValueError:
+                # backwards compat
+                result = default.get(access_key) if value.lower().strip() == "false" else 2
+            computed_settings[access_key] = result
         else:
             computed_settings[access_key] = existing_value_type(value)
 

--- a/test_isort.py
+++ b/test_isort.py
@@ -1405,12 +1405,12 @@ def test_consistency():
 def test_force_grid_wrap():
     """Ensures removing imports works as expected."""
     test_input = (
-      "from foo import lib6, lib7\n"
       "from bar import lib2\n"
+      "from foo import lib6, lib7\n"
     )
     test_output = SortImports(
       file_contents=test_input,
-      force_grid_wrap=True,
+      force_grid_wrap=2,
       multi_line_output=WrapModes.VERTICAL_HANGING_INDENT
       ).output
     assert test_output == """from bar import lib2
@@ -1419,6 +1419,12 @@ from foo import (
     lib7
 )
 """
+    test_output = SortImports(
+      file_contents=test_input,
+      force_grid_wrap=3,
+      multi_line_output=WrapModes.VERTICAL_HANGING_INDENT
+      ).output
+    assert test_output == test_input
 
 
 def test_force_grid_wrap_long():
@@ -1430,7 +1436,7 @@ def test_force_grid_wrap_long():
     )
     test_output = SortImports(
       file_contents=test_input,
-      force_grid_wrap=True,
+      force_grid_wrap=2,
       multi_line_output=WrapModes.VERTICAL_HANGING_INDENT,
       line_length=9999,
       ).output


### PR DESCRIPTION
This switches --force-grid-wrap to a configurable int (#476)

Almost fully backwards compatible except one small case: when -fgw is the last arg specified before files. That's a simple fix for anyone running into it after seeing the new --help text.

More importantly this doesn't impact config files, which I'd think is more relied upon than command line args.