### PR TITLE
Support Configuration in tox.ini

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,9 +235,9 @@ To configure isort for a single user create a ``~/.isort.cfg`` file:
     default_section=FIRSTPARTY
 
 Additionally, you can specify project level configuration simply by placing a ``.isort.cfg`` file at the root of your
-project. isort will look up to 25 directories up, from the the file it is ran against, to find a project specific configuration.
+project. isort will look up to 25 directories up, from the file it is ran against, to find a project specific configuration.
 
-Or, if you prefer, you can add an isort section to your project's ``setup.cfg`` with any desired settings.
+Or, if you prefer, you can add an isort section to your project's ``setup.cfg`` or ``tox.ini`` file with any desired settings.
 
 You can then override any of these settings by using command line arguments, or by passing in override values to the
 SortImports class.

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -113,6 +113,7 @@ def from_path(path):
     _update_settings_with_config(path, '.editorconfig', '~/.editorconfig', ('*', '*.py', '**.py'), computed_settings)
     _update_settings_with_config(path, '.isort.cfg', '~/.isort.cfg', ('settings', 'isort'), computed_settings)
     _update_settings_with_config(path, 'setup.cfg', None, ('isort', ), computed_settings)
+    _update_settings_with_config(path, 'tox.ini', None, ('isort', ), computed_settings)
     return computed_settings
 
 


### PR DESCRIPTION
Fixes issue #487

Thanks to _update_settings_with_config this was a one line addition.
Added mention in README.rst (and fixed nearby double "the" typo). I
didn't see specific tests for finding correct config file.