### PR TITLE
Fix smart lines after import section for async functions

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -554,7 +554,7 @@ class SortImports(object):
             if self.config['lines_after_imports'] != -1:
                 self.out_lines[imports_tail:0] = ["" for line in range(self.config['lines_after_imports'])]
             elif next_construct.startswith("def") or next_construct.startswith("class") or \
-               next_construct.startswith("@"):
+               next_construct.startswith("@") or next_construct.startswith("async def"):
                 self.out_lines[imports_tail:0] = ["", ""]
             else:
                 self.out_lines[imports_tail:0] = [""]

--- a/test_isort.py
+++ b/test_isort.py
@@ -919,6 +919,16 @@ def test_smart_lines_after_import_section():
                                                             "def my_function():\n"
                                                             "    pass\n")
 
+    # two spaces if an async method after imports
+    test_input = ("from a import b\n"
+                  "async def my_function():\n"
+                  "    pass\n")
+    assert SortImports(file_contents=test_input).output == ("from a import b\n"
+                                                            "\n"
+                                                            "\n"
+                                                            "async def my_function():\n"
+                                                            "    pass\n")
+
     # two spaces if a method or class after imports - even if comment before function
     test_input = ("from a import b\n"
                   "# comment should be ignored\n"


### PR DESCRIPTION
With this changes `isort` should properly add default two blank lines after import section when the next line starts with `async def` #453 .
