### PR TITLE
Replaced the --enforce-whitespace option with --ignore-whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 - Fixed issue #491: Non ending parentheses withing single line comments no longer cause formatting issues
 Breaking Changes:
     - Fixed issue #511: All command line options with an underscore, have had the underscore replaced with a dash for consistency. This effects: multi-line, add-import, remove-import, force-adds, --force-single-line-imports, and length-sort.
+    - Replaced the `--enforce-whitespace` option with `--ignore-whitespace` to restore original behavior of strict whitespace by default
 
 ### 4.2.7
 - Added `--virtual-env` switch command line option

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -170,7 +170,7 @@ class SortImports(object):
         if check:
             check_output = self.output
             check_against = file_contents
-            if not self.config['enforce_white_space']:
+            if self.config['ignore_whitespace']:
                 check_output = check_output.replace("\n", "").replace(" ", "")
                 check_against = check_against.replace("\n", "").replace(" ", "")
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -183,8 +183,8 @@ def create_parser():
     parser.add_argument('-c', '--check-only', action='store_true', dest="check",
                         help='Checks the file for unsorted / unformatted imports and prints them to the '
                              'command line without modifying the file.')
-    parser.add_argument('-ws', '--enforce-white-space', action='store_true', dest="enforce_white_space",
-                        help='Tells isort to enforce white space difference when --check-only is being used.')
+    parser.add_argument('-ws', '--ignore-whitespace', action='store_true', dest="ignore_whitespace",
+                        help='Tells isort to ignore whitespace differences when --check-only is being used.')
     parser.add_argument('-sl', '--force-single-line-imports', dest='force_single_line', action='store_true',
                         help='Forces all from imports to appear on their own line')
     parser.add_argument('-ds', '--no-sections', help='Put all imports into the same section bucket', dest='no_sections',

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -106,7 +106,7 @@ default = {'force_to_top': [],
            'force_grid_wrap': 0,
            'force_sort_within_sections': False,
            'show_diff': False,
-           'enforce_white_space': False}
+           'ignore_whitespace': False}
 
 
 @lru_cache()

--- a/test_isort.py
+++ b/test_isort.py
@@ -2041,3 +2041,18 @@ def test_alias_using_paren_issue_466():
     assert  SortImports(file_contents=test_input, line_length=50, multi_line_output=5,
                         use_parentheses=True).output == expected_output
 
+
+def test_strict_whitespace_by_default(capsys):
+    test_input = ('import os\n'
+                  'from django.conf import settings\n')
+    SortImports(file_contents=test_input, check=True)
+    out, err = capsys.readouterr()
+    assert out == 'ERROR:  Imports are incorrectly sorted.\n'
+
+
+def test_ignore_whitespace(capsys):
+    test_input = ('import os\n'
+                  'from django.conf import settings\n')
+    SortImports(file_contents=test_input, check=True, ignore_whitespace=True)
+    out, err = capsys.readouterr()
+    assert out == ''


### PR DESCRIPTION
Restores original behavior of enforcing whitespace by default. The
behavior was broken in a backwards incompatible way starting with commit
5f6d4bd45e0fa8e3b6b2bea81d3eb7368ee312c3. Ignoring whitespace is now
opt-in instead of opt-out.

Ignoring whitespace by default has lead to a number of confused users,
myself included. CI would seemingly pass but isort --apply would still
make changes. Some users have asked for the original behavior be
restored and the new feature be behind a CLI argument.

Refs #378
Fixes #423
Fixes #481