### PR TITLE
Reorder CHANGELOG to be in reverse chronological order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,62 @@
 Changelog
 =========
 
-### 4.0.0
-- Removed all external dependencies
+### 4.2.8 - In progress
+- Fixed issue #299: long lines occasionally not wrapped
+- Fixed issue #432: No longer add import inside class when class starts at top of file after encoding comment
+- Fixed issue #440: Added missing `--use-parentheses` option to command line tool and documentation
+- Fixed issue #496: import* imports now get successfully identified and reformatted instead of deleted
+- Fixed issue #491: Non ending parentheses withing single line comments no longer cause formatting issues
+Breaking Changes:
+    - Fixed issue #511: All command line options with an underscore, have had the underscore replaced with a dash for consistency. This effects: multi-line, add-import, remove-import, force-adds, --force-single-line-imports, and length-sort.
+
+### 4.2.7
+- Added `--virtual-env` switch command line option
+
+### 4.2.6
+- Added --enforce-whitespace option to go along with --check-only for more exact checks (issue #423)
+- Fixed imports with a tailing '\' and no space in-between getting removed (issue #425)
+
+### 4.2.5
+- Fixed an issue that caused modules to inccorectly be matched as thirdparty when they simply had `src` in the leading path, even if they weren't withing $VIRTUALENV/src #414
+
+### 4.2.4
+- Fixed an issue that caused module that contained functions before doc strings, to incorrectly place imports
+- Fixed regression in how `force_alphabetical_sort` was being interpretted (issue #409)
+- Fixed stray print statement printing skipped files (issue #411)
+- Added option for forcing imports into a single bucket: `no_sections`
+- Added option for new lines between import types (from, straight): `lines_between_sections`
+
+### 4.2.3
+- Fixed a large number of priority bugs - bug fix only release
+
+### 4.2.2
+- Give an error message when isort is unable to determine where to place a module
+- Allow imports to be sorted by module, independent of import_type, when `force_sort_within_sections` option is set
+- Fixed an issue that caused Python files with 2 top comments not to be sorted
+
+### 4.2.1
+- Hot fix release to fix code error when skipping globs
+
+### 4.2.0
+- Added option "NOQA" Do not wrap lines, but add a noqa statement at the end
+- Added support for running isort recursively, simply with a standalone `isort` command
+- Added support to run isort library as a module
+- Added compatibility for Python 3.5
+- Fixed performance issue (#338) when running on project with lots of skipped directories
+- Fixed issue #328: extra new can occasionally occur when using alphabetical-only sort
+- Fixed custom sections parsing from config file (unicode string -> list)
+- Updated pylama extension to the correct entry point
+- Skip files even when file_contents is provided if they are explicitly in skip list
+- Removed always showing isort banner, keeping it for when the version is requested, verbose is used, or show_logo setting is set.
+
+### 4.1.2
+- Fixed issue #323: Accidental default configuration change introduced
+
+### 4.1.1
+- Added support for partial file match skips (thanks to @Amwam)
+- Added support for --quiet option to only show errors when running isort
+- Fixed issue #316: isort added new lines incorrectly when a top-of line comment is present
 
 ### 4.1.0
 - Started keeping a log of all changes between releases
@@ -18,59 +72,5 @@ Changelog
 - Fixed issue #289: Sections order not being respected
 - Fixed issue #296: Made it more clear how to set arguments more then once
 
-### 4.1.1
-- Added support for partial file match skips (thanks to @Amwam)
-- Added support for --quiet option to only show errors when running isort
-- Fixed issue #316: isort added new lines incorrectly when a top-of line comment is present
-
-### 4.1.2
-- Fixed issue #323: Accidental default configuration change introduced
-
-### 4.2.0
-- Added option "NOQA" Do not wrap lines, but add a noqa statement at the end
-- Added support for running isort recursively, simply with a standalone `isort` command
-- Added support to run isort library as a module
-- Added compatibility for Python 3.5
-- Fixed performance issue (#338) when running on project with lots of skipped directories
-- Fixed issue #328: extra new can occasionally occur when using alphabetical-only sort
-- Fixed custom sections parsing from config file (unicode string -> list)
-- Updated pylama extension to the correct entry point
-- Skip files even when file_contents is provided if they are explicitly in skip list
-- Removed always showing isort banner, keeping it for when the version is requested, verbose is used, or show_logo setting is set.
-
-### 4.2.1
-- Hot fix release to fix code error when skipping globs
-
-### 4.2.2
-- Give an error message when isort is unable to determine where to place a module
-- Allow imports to be sorted by module, independent of import_type, when `force_sort_within_sections` option is set
-- Fixed an issue that caused Python files with 2 top comments not to be sorted
-
-### 4.2.3
-- Fixed a large number of priority bugs - bug fix only release
-
-### 4.2.4
-- Fixed an issue that caused module that contained functions before doc strings, to incorrectly place imports
-- Fixed regression in how `force_alphabetical_sort` was being interpretted (issue #409)
-- Fixed stray print statement printing skipped files (issue #411)
-- Added option for forcing imports into a single bucket: `no_sections`
-- Added option for new lines between import types (from, straight): `lines_between_sections`
-
-### 4.2.5
-- Fixed an issue that caused modules to inccorectly be matched as thirdparty when they simply had `src` in the leading path, even if they weren't withing $VIRTUALENV/src #414
-
-### 4.2.6
-- Added --enforce-whitespace option to go along with --check-only for more exact checks (issue #423)
-- Fixed imports with a tailing '\' and no space in-between getting removed (issue #425)
-
-### 4.2.7
-- Added `--virtual-env` switch command line option
-
-### 4.2.8 - In progress
-- Fixed issue #299: long lines occasionally not wrapped
-- Fixed issue #432: No longer add import inside class when class starts at top of file after encoding comment
-- Fixed issue #440: Added missing `--use-parentheses` option to command line tool and documentation
-- Fixed issue #496: import* imports now get successfully identified and reformatted instead of deleted
-- Fixed issue #491: Non ending parentheses withing single line comments no longer cause formatting issues
-Breaking Changes:
-    - Fixed issue #511: All command line options with an underscore, have had the underscore replaced with a dash for consistency. This effects: multi-line, add-import, remove-import, force-adds, --force-single-line-imports, and length-sort.
+### 4.0.0
+- Removed all external dependencies


### PR DESCRIPTION
It is a bit unusual and unconventional to order a CHANGELOG with the
most recent release at the bottom. Due to this, it is easy for a new
user to incorrectly read version 4.0.0 as the latest release. Bring
CHANGELOG into more typical ordering to reduce confusion.

Follows suggestions from "Keep a CHANGELOG": http://keepachangelog.com/.

> List releases in reverse-chronological order (newest on top).