### PR TITLE
Increase flake8 coverage

### DIFF
--- a/isort/__init__.py
+++ b/isort/__init__.py
@@ -22,7 +22,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from . import settings
-from .isort import SortImports
+from . import settings  # noqa: F401
+from .isort import SortImports  # noqa: F401
 
 __version__ = "4.2.13"

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -162,7 +162,7 @@ class SortImports(object):
                 self.incorrectly_sorted = True
                 try:
                     compile(self._strip_top_comments(self.in_lines), self.file_path, 'exec', 0, 1)
-                    print("ERROR: {0} isort would have introduced syntax errors, please report to the project!". \
+                    print("ERROR: {0} isort would have introduced syntax errors, please report to the project!".
                           format(self.file_path))
                 except SyntaxError:
                     print("ERROR: {0} File contains syntax errors.".format(self.file_path))
@@ -407,7 +407,6 @@ class SortImports(object):
                         from_imports.remove(from_import)
                         section_output.append(import_statement)
 
-
             if from_imports:
                 comments = self.comments['from'].pop(module, ())
                 if "*" in from_imports and self.config['combine_star']:
@@ -558,7 +557,7 @@ class SortImports(object):
                 section_title = self.config.get('import_heading_' + str(section_name).lower(), '')
                 if section_title:
                     section_comment = "# {0}".format(section_title)
-                    if not section_comment in self.out_lines[0:1] and not section_comment in self.in_lines[0:1]:
+                    if section_comment not in self.out_lines[0:1] and section_comment not in self.in_lines[0:1]:
                         section_output.insert(0, section_comment)
                 output += section_output + ([''] * self.config['lines_between_sections'])
 
@@ -721,7 +720,7 @@ class SortImports(object):
     def _format_natural(import_line):
         import_line = import_line.strip()
         if not import_line.startswith("from ") and not import_line.startswith("import "):
-            if not "." in import_line:
+            if "." not in import_line:
                 return "import {0}".format(import_line)
             parts = import_line.split(".")
             end = parts.pop(-1)
@@ -826,14 +825,14 @@ class SortImports(object):
                     while not line.strip().endswith(")") and not self._at_end():
                         line, comments, new_comments = self._strip_comments(self._get_line(), comments)
                         stripped_line = self._strip_syntax(line).strip()
-                        if import_type == "from" and stripped_line and not " " in stripped_line and new_comments:
+                        if import_type == "from" and stripped_line and " " not in stripped_line and new_comments:
                             nested_comments[stripped_line] = comments[-1]
                         import_string += "\n" + line
                 else:
                     while line.strip().endswith("\\"):
                         line, comments, new_comments = self._strip_comments(self._get_line(), comments)
                         stripped_line = self._strip_syntax(line).strip()
-                        if import_type == "from" and stripped_line and not " " in stripped_line and new_comments:
+                        if import_type == "from" and stripped_line and " " not in stripped_line and new_comments:
                             nested_comments[stripped_line] = comments[-1]
                         if import_string.strip().endswith(" import") or line.strip().startswith("import "):
                             import_string += "\n" + line
@@ -880,8 +879,8 @@ class SortImports(object):
 
                     if len(self.out_lines) > max(self.import_index, self._first_comment_index_end + 1, 1) - 1:
                         last = self.out_lines and self.out_lines[-1].rstrip() or ""
-                        while (last.startswith("#") and not last.endswith('"""') and not last.endswith("'''") and not
-                               'isort:imports-' in last):
+                        while (last.startswith("#") and not last.endswith('"""') and not last.endswith("'''") and
+                               'isort:imports-' not in last):
                             self.comments['above']['from'].setdefault(import_from, []).insert(0, self.out_lines.pop(-1))
                             if len(self.out_lines) > max(self.import_index - 1, self._first_comment_index_end + 1, 1) - 1:
                                 last = self.out_lines[-1].rstrip()
@@ -904,7 +903,7 @@ class SortImports(object):
 
                             last = self.out_lines and self.out_lines[-1].rstrip() or ""
                             while (last.startswith("#") and not last.endswith('"""') and not last.endswith("'''") and
-                                   not 'isort:imports-' in last):
+                                   'isort:imports-' not in last):
                                 self.comments['above']['straight'].setdefault(module, []).insert(0,
                                                                                                  self.out_lines.pop(-1))
                                 if len(self.out_lines) > 0:

--- a/isort/pie_slice.py
+++ b/isort/pie_slice.py
@@ -146,8 +146,8 @@ if PY3:
 
     __all__ = common + ['urllib']
 else:
-    from itertools import ifilter as filter
-    from itertools import imap as map
+    from itertools import ifilter as filter  # noqa: F401
+    from itertools import imap as map  # noqa: F401
     from itertools import izip as zip
     from decimal import Decimal, ROUND_HALF_EVEN
 
@@ -527,7 +527,7 @@ if sys.version_info < (3, 2):
         return decorating_function
 
 else:
-    from functools import lru_cache
+    from functools import lru_cache  # noqa: F401
 
 
 class OrderedSet(collections.MutableSet):

--- a/isort/pie_slice.py
+++ b/isort/pie_slice.py
@@ -23,9 +23,7 @@ from __future__ import absolute_import
 
 import abc
 import collections
-import functools
 import sys
-from numbers import Integral
 
 __version__ = "1.1.0"
 
@@ -153,7 +151,6 @@ else:
     from itertools import izip as zip
     from decimal import Decimal, ROUND_HALF_EVEN
 
-    import codecs
     str = unicode
     chr = unichr
     input = raw_input

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-MAX_CONFIG_SEARCH_DEPTH = 25 # The number of parent directories isort will look for a config file within
+MAX_CONFIG_SEARCH_DEPTH = 25  # The number of parent directories isort will look for a config file within
 DEFAULT_SECTIONS = ('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')
 
 WrapModes = ('GRID', 'VERTICAL', 'HANGING_INDENT', 'VERTICAL_HANGING_INDENT', 'VERTICAL_GRID', 'VERTICAL_GRID_GROUPED', 'NOQA')

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Skip linting this file until it's cleaned up:
+# https://github.com/timothycrosley/isort/issues/554
+# flake8: noqa
+
 sources = """
 eNrcvWmXG1l2INYzY1tjeGYk2ePtg32iQVGIKCKDSXZpyylUqVRFqqmuYvFwUVPOSoGRQGRmNJER
 YESAiVSrz/Ev8Dn+Bf4p/mu+29tfAMjqKo3PlNTMTOC9+7b77rv7/T//9e8+/Cx980fr23y+ai7z

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,11 @@
 universal = 1
 
 [flake8]
-ignore = F401,F403,E502,E123,E127,E128,E303,E713,E111,E241,E302,E121,E261,W391
 max-line-length = 160
+ignore =
+    # The default ignore list:
+    E121,E123,E126,E226,E24,E704,
+    # Our additions:
+    # E127: continuation line over-indented for visual indent
+    # E128: continuation line under-indented for visual indent
+    E127,E128

--- a/test_isort.py
+++ b/test_isort.py
@@ -30,7 +30,6 @@ import sys
 import tempfile
 
 from isort.isort import SortImports, exists_case_sensitive
-from isort.pie_slice import *
 from isort.settings import WrapModes
 
 SHORT_IMPORT = "from third_party import lib1, lib2, lib3, lib4"
@@ -362,6 +361,7 @@ def test_qa_comment_case():
     test_input = "import veryveryveryveryveryveryveryveryveryveryvery  # NOQA"
     test_output = SortImports(file_contents=test_input, line_length=40, multi_line_output=WrapModes.NOQA).output
     assert test_output == "import veryveryveryveryveryveryveryveryveryveryvery  # NOQA\n"
+
 
 def test_length_sort():
     """Test setting isort to sort on length instead of alphabetically."""
@@ -888,7 +888,7 @@ def test_atomic_mode():
                                                                           "from b import c, d\n")
 
     # with syntax error content is not changed
-    test_input += "while True print 'Hello world'" # blatant syntax error
+    test_input += "while True print 'Hello world'"  # blatant syntax error
     assert SortImports(file_contents=test_input, atomic=True).output == test_input
 
 
@@ -1334,7 +1334,6 @@ def test_place_comments():
     assert test_output == expected_output
     test_output = SortImports(file_contents=test_output, known_third_party=['django']).output
     assert test_output == expected_output
-
 
 
 def test_placement_control():
@@ -1789,6 +1788,7 @@ def test_lines_between_sections():
     assert SortImports(file_contents=test_input, lines_between_sections=2).output == ('import os\n\n\n'
                                                                                       'from bar import baz\n')
 
+
 def test_forced_sepatate_globs():
     """Test to ensure that forced_separate glob matches lines"""
     test_input = ('import os\n'
@@ -2033,7 +2033,6 @@ def test_alias_using_paren_issue_466():
     expected_output = ('from django.db.backends.mysql.base import (\n'
                        '    DatabaseWrapper as MySQLDatabaseWrapper)\n')
     assert SortImports(file_contents=test_input, line_length=50, use_parentheses=True).output == expected_output
-
 
     test_input = 'from django.db.backends.mysql.base import DatabaseWrapper as MySQLDatabaseWrapper\n'
     expected_output = ('from django.db.backends.mysql.base import (\n'

--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,5 @@ deps =
 
 [testenv:lint]
 basepython = python2.7
-deps = flake8
-commands = flake8 isort setup.py test_isort.py
+deps = flake8==3.3.0
+commands = flake8


### PR DESCRIPTION
**1) Fix more lint warnings reported by flake8:**
Fixes:
```
test_isort.py:33:1: F403 'from isort.pie_slice import *' used; unable to detect undefined names
test_isort.py:33:1: F401 'isort.pie_slice.*' imported but unused
test_isort.py:366:1: E302 expected 2 blank lines, found 1
test_isort.py:891:51: E261 at least two spaces before inline comment
test_isort.py:1340:1: E303 too many blank lines (3)
test_isort.py:1792:1: E302 expected 2 blank lines, found 1
test_isort.py:2038:5: E303 too many blank lines (2)
isort/isort.py:165:114: E502 the backslash is redundant between brackets
isort/isort.py:413:13: E303 too many blank lines (2)
isort/isort.py:563:24: E713 test for membership should be 'not in'
isort/isort.py:726:16: E713 test for membership should be 'not in'
isort/isort.py:831:72: E713 test for membership should be 'not in'
isort/isort.py:838:72: E713 test for membership should be 'not in'
isort/isort.py:885:115: E713 test for membership should be 'not in'
isort/isort.py:909:36: E713 test for membership should be 'not in'
isort/pie_slice.py:26:1: F401 'functools' imported but unused
isort/pie_slice.py:28:1: F401 'numbers.Integral' imported but unused
isort/pie_slice.py:156:5: F401 'codecs' imported but unused
isort/settings.py:39:29: E261 at least two spaces before inline comment
```

**2) Increase flake8 coverage:**
Enables more of flake8's default rules and makes CI check all files, not just a subset. Also pins the version of flake8 to avoid CI non-determinism when newer versions add/adjust the default rules.

The `# noqa: F401` entries in `pie_slice.py` are required due to https://github.com/PyCQA/pyflakes/issues/276.

Refs #551.