### PR TITLE
Prefer https URLs over http in docs and comments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 ########
 
 .. image:: https://badge.fury.io/py/isort.svg
-    :target: http://badge.fury.io/py/isort
+    :target: https://badge.fury.io/py/isort
     :alt: PyPI version
 
 .. image:: https://travis-ci.org/timothycrosley/isort.svg?branch=master

--- a/isort/natural.py
+++ b/isort/natural.py
@@ -8,7 +8,7 @@ usage:
 Copyright (C) 2013  Timothy Edmund Crosley
 
 Implementation originally from @HappyLeapSecond stack overflow user in response to:
-   http://stackoverflow.com/questions/5967500/how-to-correctly-sort-a-string-with-a-number-inside
+   https://stackoverflow.com/questions/5967500/how-to-correctly-sort-a-string-with-a-number-inside
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation

--- a/isort/pie_slice.py
+++ b/isort/pie_slice.py
@@ -460,7 +460,7 @@ if sys.version_info < (3, 2):
         View the cache statistics named tuple (hits, misses, maxsize, currsize) with
         f.cache_info().  Clear the cache and statistics with f.cache_clear().
         Access the underlying function with f.__wrapped__.
-        See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+        See: https://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
 
         """
         def decorating_function(user_function, tuple=tuple, sorted=sorted, len=len, KeyError=KeyError):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,3 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
 envlist =
     isort-check,


### PR DESCRIPTION
Fixed all URLs where https is supported. Dropped the auto-generated, boilerplate from `tox.ini` instead of editing the URL.