### PR TITLE
Set skipped=True when we skip the file

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -113,6 +113,7 @@ class SortImports(object):
                     file_contents = file_to_import_sort.read()
 
         if file_contents is None or ("isort:" + "skip_file") in file_contents:
+            self.skipped = True
             return
 
         self.in_lines = file_contents.split("\n")

--- a/test_isort.py
+++ b/test_isort.py
@@ -506,6 +506,15 @@ def test_skip_with_file_name():
     assert skipped
 
 
+def test_skip_within_file():
+    """Ensure skipping a whole file works."""
+    test_input = ("# isort:skip_file\n"
+                  "import django\n"
+                  "import myproject\n")
+
+    assert SortImports(file_contents=test_input, known_third_party=['django']).skipped
+
+
 def test_force_to_top():
     """Ensure forcing a single import to the top of its category works as expected."""
     test_input = ("import lib6\n"


### PR DESCRIPTION
We already do this when the configuration specifies skipping a file, but not when the file is empty or the _file_ specifies skipping.

The "skipped" flag is relied upon by some tooling (I'm not sure if it constitutes public API, but it should be fixed anyway), and that tooling is failing in these cases.