### PR TITLE
Fix case-sensitive path existence check in Mac OS X

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -963,7 +963,7 @@ def exists_case_sensitive(path):
     can only import using the case of the real file.
     """
     result = os.path.exists(path)
-    if sys.platform.startswith('win') and result:
+    if (sys.platform.startswith('win') or sys.platform == 'darwin') and result:
         directory, basename = os.path.split(path)
         result = basename in os.listdir(directory)
     return result

--- a/test_isort.py
+++ b/test_isort.py
@@ -1625,7 +1625,7 @@ def test_comment_at_top_of_file():
 
 
 def test_alphabetic_sorting():
-    """Test to ensure isort correctly handles top of file comments"""
+    """Test to ensure isort correctly handles single line imports"""
     test_input = ("import unittest\n"
                   "\n"
                   "import ABC\n"


### PR DESCRIPTION
Mac OS X works in a case-insensitive manner when checking path existence. This PR applies the same logic for Mac OS X installations as isort has for windows