### PR TITLE
Add no_lines_before option to let sections not be split from previous

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -583,6 +583,9 @@ class SortImports(object):
                     section_comment = "# {0}".format(section_title)
                     if section_comment not in self.out_lines[0:1] and section_comment not in self.in_lines[0:1]:
                         section_output.insert(0, section_comment)
+                if section_name in self.config['no_lines_before']:
+                    while output and output[-1].strip() == '':
+                        output.pop()
                 output += section_output + ([''] * self.config['lines_between_sections'])
 
         while output and output[-1].strip() == '':

--- a/isort/main.py
+++ b/isort/main.py
@@ -238,6 +238,8 @@ def create_parser():
     parser.add_argument('-lai', '--lines-after-imports', dest='lines_after_imports', type=int)
     parser.add_argument('-up', '--use-parentheses', dest='use_parentheses', action='store_true',
                         help='Use parenthesis for line continuation on length limit instead of slashes.')
+    parser.add_argument('-nlb', '--no-lines-before', help='Sections which should not be split with previous by empty lines',
+                        dest='no_lines_before', action='append')
 
     arguments = {key: value for key, value in itemsview(vars(parser.parse_args())) if value}
     if 'dont_order_by_type' in arguments:

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -132,7 +132,8 @@ default = {'force_to_top': [],
            'force_grid_wrap': 0,
            'force_sort_within_sections': False,
            'show_diff': False,
-           'ignore_whitespace': False}
+           'ignore_whitespace': False,
+           'no_lines_before': []}
 
 
 @lru_cache()

--- a/test_isort.py
+++ b/test_isort.py
@@ -2199,3 +2199,29 @@ def test_ensure_as_imports_sort_correctly_within_from_imports_issue_590():
     test_input = ('from os import defpath\n'
                   'from os import pathsep as separator\n')
     assert SortImports(file_contents=test_input, force_single_line=True).output == test_input
+
+
+def test_not_splitted_sections():
+    whiteline = '\n'
+    stdlib_section = 'import unittest\n'
+    firstparty_section = 'from app.pkg1 import mdl1\n'
+    local_section = 'from .pkg2 import mdl2\n'
+    statement = 'foo = bar\n'
+    test_input = (
+        stdlib_section + whiteline + firstparty_section + whiteline +
+        local_section + whiteline + statement
+    )
+
+    assert SortImports(file_contents=test_input).output == test_input
+    assert SortImports(file_contents=test_input, no_lines_before=['LOCALFOLDER']).output == \
+           (
+               stdlib_section + whiteline + firstparty_section + local_section +
+               whiteline + statement
+           )
+    assert SortImports(file_contents=test_input, no_lines_before=['FIRSTPARTY']).output == \
+           (
+               stdlib_section + firstparty_section + whiteline + local_section +
+               whiteline + statement
+           )
+    assert SortImports(file_contents=test_input, no_lines_before=['FIRSTPARTY', 'LOCALFOLDER']).output == \
+           (stdlib_section + firstparty_section + local_section + whiteline + statement)


### PR DESCRIPTION
I would like to propose a new option for optionally skip splitting by empty lines for some sections.

In our internal code style we don't split local imports and first party imports because they are parts of the same project and this will add additional 6th level of imports when we already have 5: futures,stdlib,django,thirdparty,firstparty+local

Also, it would help to solve #447