### PR TITLE
Fixed improper line seperator conversion

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -202,7 +202,7 @@ class SortImports(object):
                         return
                     if answer in ('quit', 'q'):
                         sys.exit(1)
-            with io.open(self.file_path, encoding=self.file_encoding, mode='w') as output_file:
+            with io.open(self.file_path, encoding=self.file_encoding, mode='w', newline='') as output_file:
                 output_file.write(self.output)
 
     def _show_diff(self, file_contents):


### PR DESCRIPTION
This Fixes #493. From the [io.open docs](https://docs.python.org/2/library/io.html#io.open):  

> newline controls how universal newlines works (it only applies to text mode). It can be None, '', '\n', '\r', and '\r\n'. It works as follows:

> On input, if newline is None, universal newlines mode is enabled. Lines in the input can end in '\n', '\r', or '\r\n', and these are translated into '\n' before being returned to the caller. If it is '', universal newlines mode is enabled, but line endings are returned to the caller untranslated. If it has any of the other legal values, input lines are only terminated by the given string, and the line ending is returned to the caller untranslated.
> **On output, if newline is None, any '\n' characters written are translated to the system default line separator, os.linesep. If newline is '', no translation takes place**. If newline is any of the other legal values, any '\n' characters written are translated to the given string.