### PR TITLE
Remove unconventional space after shebang

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 '''  Tool for sorting imports alphabetically, and automatically separated into sections.
 
 Copyright (C) 2013  Timothy Edmund Crosley


### PR DESCRIPTION
While allowed by most tools, it is very unconventional.