### PR TITLE
minor things to improve usability 

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -198,9 +198,10 @@ class SortImports(object):
         elif write_to_stdout:
             sys.stdout.write(self.output)
         elif file_name and not check:
+            if self.output == file_contents:
+                return
+
             if ask_to_apply:
-                if self.output == file_contents:
-                    return
                 self._show_diff(file_contents)
                 answer = None
                 while answer not in ('yes', 'y', 'no', 'n', 'quit', 'q'):
@@ -210,6 +211,7 @@ class SortImports(object):
                     if answer in ('quit', 'q'):
                         sys.exit(1)
             with io.open(self.file_path, encoding=self.file_encoding, mode='w', newline=self.line_separator) as output_file:
+                print("Fixing {0}".format(self.file_path))
                 output_file.write(self.output)
 
     def _show_diff(self, file_contents):

--- a/isort/main.py
+++ b/isort/main.py
@@ -292,6 +292,14 @@ def main():
     if 'settings_path' in arguments:
         sp = arguments['settings_path']
         arguments['settings_path'] = os.path.abspath(sp) if os.path.isdir(sp) else os.path.dirname(os.path.abspath(sp))
+        if not os.path.isdir(arguments['settings_path']):
+            print("WARNING: settings_path dir does not exist: {0}".format(arguments['settings_path']))
+
+    if 'virtual_env' in arguments:
+        venv = arguments['virtual_env']
+        arguments['virtual_env'] = os.path.abspath(venv)
+        if not os.path.isdir(arguments['virtual_env']):
+            print("WARNING: virtual_env dir does not exist: {0}".format(arguments['virtual_env']))
 
     file_names = arguments.pop('files', [])
     if file_names == ['-']:


### PR DESCRIPTION
While configuring isort as a pre-commit hook, I had some issue because I was misusing the command (I was using path with tilde to --virtual-env i.e: ~/dev/env) and it took me some debugging to find out why it wasn't sorting my imports correctly. In fact when providing a virtual_env directory that does not exist, it silently ignores it but this has a significant impact on the import sorting.

So I ended up implementing the following:
- Use abspath for virtual_env (to make it consistent with settings_path)
- print warning in case virtual_env or settings_path directories don't exist
- print 'Fixing {filepath}' whenever isort actually overwrites a file (I believe it is a good practice for such library and it's very helpful when used as a hook)