### PR TITLE
Fix 'lines_after_imports' detection

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -625,7 +625,7 @@ class SortImports(object):
 
             if self.config['lines_after_imports'] != -1:
                 self.out_lines[imports_tail:0] = ["" for line in range(self.config['lines_after_imports'])]
-            elif next_construct.startswith("def") or next_construct.startswith("class") or \
+            elif next_construct.startswith("def ") or next_construct.startswith("class ") or \
                next_construct.startswith("@") or next_construct.startswith("async def"):
                 self.out_lines[imports_tail:0] = ["", ""]
             else:


### PR DESCRIPTION
Fix a bug where variables are mistaken for function definitions. 

This fixes a bug wherein a variable definition prefixed ``default_`` would
be confused with a ``def foo()``, because they both start with ``def``.
(Whether it's a function def or a variable changes the
expected default lines-after-imports behaviour. Noticed this when
isort and yapf began clashing over these cases.)