### PR TITLE
Remove additional references to Python 3.3

### DIFF
--- a/.env
+++ b/.env
@@ -22,10 +22,6 @@ if [ ! -d "venv" ]; then
                 pyvenv-3.5 $@
             elif hash pyvenv-3.4 2>/dev/null; then
                 pyvenv-3.4 $@
-            elif hash pyvenv-3.3 2>/dev/null; then
-                pyvenv-3.3 $@
-            elif hash pyvenv-3.2 2>/dev/null; then
-                pyvenv-3.2 $@
             else
                 python3 -m venv $@
             fi


### PR DESCRIPTION
Support for Python 3.3 was removed in commit 9ac80c514fc26ebed0bec0e8d67ae6b0b4e50679.