### PR TITLE
Smart newlines no longer skips multi-line string assignments

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -762,6 +762,8 @@ class SortImports(object):
                         self._in_quote = line[index]
                 elif line[index] == "#":
                     break
+                elif line[index] not in (' ', '\t'):
+                    break
                 index += 1
 
         return skip_line or self._in_quote or self._in_top_comment

--- a/test_isort.py
+++ b/test_isort.py
@@ -999,6 +999,19 @@ def test_smart_lines_after_import_section():
                                                             "def my_function():\n"
                                                             "    pass\n")
 
+    # Ensure logic doesn't incorrectly skip over assignments to multi-line strings
+    test_input = ("from a import b\n"
+                  'X = """test\n'
+                  '"""\n'
+                  "def my_function():\n"
+                  "    pass\n")
+    assert SortImports(file_contents=test_input).output == ("from a import b\n"
+                                                            "\n"
+                                                            'X = """test\n'
+                                                            '"""\n'
+                                                            "def my_function():\n"
+                                                            "    pass\n")
+
 
 def test_settings_combine_instead_of_overwrite():
     """Test to ensure settings combine logically, instead of fully overwriting."""


### PR DESCRIPTION
Prior to this change, the smart newline code was doing the wrong thing when
faced with code like this:

```
from x import y

something = """
test"""

class Blah():
    pass
```

The smart new lines code attempts to find the first construct after the import
block, and uses the `_skip_line` function to determine where that construct
starts.  However, `_skip_line` seems to incorrectly assume that a line ending
with `"""` is a docstring.   It then goes on to treat `class Blah` as the first
construct, and adds 2 new lines after imports instead of the 1 that should be
chosen.

I've fixed this by updating `_skip_lines` to stop iterating over the characters
of a line if it finds something that is neither whitespace, the start of a
string or a comment.