### PR TITLE
Fix 613 Addresses error recognizing "from .import foo"

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -861,6 +861,7 @@ class SortImports(object):
                     continue
 
                 line = line.replace("\t", " ").replace('import*', 'import *')
+                line = line.replace(" .import", " . import")
                 if self.import_index == -1:
                     self.import_index = self.index - 1
 


### PR DESCRIPTION
I chose to replace " .import" with " . import" because without the initial space, the change might create an error when ".import" was intentional, for example:

from CoolPackage.import ExcellentClass