### PR TITLE
Fix 638

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -831,6 +831,9 @@ class SortImports(object):
         self._in_top_comment = False
         while not self._at_end():
             line = self._get_line()
+            line = line.replace("from.import", "from . import")
+            line = line.replace("\t", " ").replace('import*', 'import *')
+            line = line.replace(" .import", " . import")
             statement_index = self.index
             skip_line = self._skip_line(line)
 
@@ -855,14 +858,11 @@ class SortImports(object):
                 continue
 
             for line in (line.strip() for line in line.split(";")):
-                line = line.replace("from.import", "from . import")
                 import_type = self._import_type(line)
                 if not import_type:
                     self.out_lines.append(line)
                     continue
 
-                line = line.replace("\t", " ").replace('import*', 'import *')
-                line = line.replace(" .import", " . import")
                 if self.import_index == -1:
                     self.import_index = self.index - 1
 

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -855,6 +855,7 @@ class SortImports(object):
                 continue
 
             for line in (line.strip() for line in line.split(";")):
+                line = line.replace("from.import", "from . import")
                 import_type = self._import_type(line)
                 if not import_type:
                     self.out_lines.append(line)

--- a/test_isort.py
+++ b/test_isort.py
@@ -871,8 +871,8 @@ def test_relative_import_with_space():
     """Tests the case where the relation and the module that is being imported from is separated with a space."""
     test_input = ("from ... fields.sproqet import SproqetCollection")
     assert SortImports(file_contents=test_input).output == ("from ...fields.sproqet import SproqetCollection\n")
-    test_input = ("from .input foo")
-    test_output = ("from . input foo")
+    test_input = ("from .import foo")
+    test_output = ("from . import foo")
     assert SortImports(file_contents=test_input).output == test_output
     test_input = ("from.import foo")
     test_output = ("from . import foo")

--- a/test_isort.py
+++ b/test_isort.py
@@ -872,10 +872,10 @@ def test_relative_import_with_space():
     test_input = ("from ... fields.sproqet import SproqetCollection")
     assert SortImports(file_contents=test_input).output == ("from ...fields.sproqet import SproqetCollection\n")
     test_input = ("from .import foo")
-    test_output = ("from . import foo")
+    test_output = ("from . import foo\n")
     assert SortImports(file_contents=test_input).output == test_output
     test_input = ("from.import foo")
-    test_output = ("from . import foo")
+    test_output = ("from . import foo\n")
     assert SortImports(file_contents=test_input).output == test_output
 
 

--- a/test_isort.py
+++ b/test_isort.py
@@ -879,7 +879,6 @@ def test_relative_import_with_space():
     assert SortImports(file_contents=test_input).output == test_output
 
 
-
 def test_multiline_import():
     """Test the case where import spawns multiple lines with inconsistent indentation."""
     test_input = ("from pkg \\\n"

--- a/test_isort.py
+++ b/test_isort.py
@@ -871,6 +871,13 @@ def test_relative_import_with_space():
     """Tests the case where the relation and the module that is being imported from is separated with a space."""
     test_input = ("from ... fields.sproqet import SproqetCollection")
     assert SortImports(file_contents=test_input).output == ("from ...fields.sproqet import SproqetCollection\n")
+    test_input = ("from .input foo")
+    test_output = ("from . input foo")
+    assert SortImports(file_contents=test_input).output == test_output
+    test_input = ("from.import foo")
+    test_output = ("from . import foo")
+    assert SortImports(file_contents=test_input).output == test_output
+
 
 
 def test_multiline_import():
@@ -1620,7 +1627,7 @@ def test_fcntl():
 
 
 def test_import_split_is_word_boundary_aware():
-    """Test to ensure that isort splits words in a boundry aware mannor"""
+    """Test to ensure that isort splits words in a boundary aware manner"""
     test_input = ("from mycompany.model.size_value_array_import_func import \\\n"
                 "    get_size_value_array_import_func_jobs")
     test_output = SortImports(file_contents=test_input,


### PR DESCRIPTION
Allowed for "from.import foo"  by converting to "from . import" and added test for Issue 613 and a test for the new case added here.