### PR TITLE
added a test for imports created at load time, such as six.moves.

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -278,10 +278,9 @@ class SortImports(object):
         stdlib_lib_prefix = os.path.normcase(sysconfig.get_paths()['stdlib'])
 
         for prefix in paths:
-            module_path = "/".join((prefix, module_name.replace(".", "/")))
             package_path = "/".join((prefix, module_name.split(".")[0]))
-            is_module = (exists_case_sensitive(module_path + ".py") or
-                         exists_case_sensitive(module_path + ".so"))
+            is_module = (exists_case_sensitive(package_path + ".py") or
+                         exists_case_sensitive(package_path + ".so"))
             is_package = exists_case_sensitive(package_path) and os.path.isdir(package_path)
             if is_module or is_package:
                 if ('site-packages' in prefix or 'dist-packages' in prefix or

--- a/test_isort.py
+++ b/test_isort.py
@@ -2284,3 +2284,27 @@ def test_no_inline_sort():
     )
     assert SortImports(file_contents=test_input, no_inline_sort=False, force_single_line=True).output == expected
     assert SortImports(file_contents=test_input, no_inline_sort=True, force_single_line=True).output == expected
+
+
+def test_relative_import_of_a_module():
+    """Imports can be dynamically created (PEP302) and is used by modules such as six.  This test ensures that
+    these types of imports are still sorted to the correct type instead of being categorized as local."""
+    test_input = ('from __future__ import absolute_import\n'
+                  '\n'
+                  'import itertools\n'
+                  '\n'
+                  'from six import add_metaclass\n'
+                  '\n'
+                  'from six.moves import asd\n'
+                  )
+
+    expected_results = ('from __future__ import absolute_import\n'
+                        '\n'
+                        'import itertools\n'
+                        '\n'
+                        'from six import add_metaclass\n'
+                        'from six.moves import asd\n'
+                        )
+
+    sorted_result = SortImports(file_contents=test_input, force_single_line=True).output
+    assert sorted_result == expected_results


### PR DESCRIPTION
also added a simplified test of import being a module or package.
fixing #594.