### PR TITLE
Handle parenthetically enclosed imports starting after an escaped line

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -884,6 +884,21 @@ class SortImports(object):
                 else:
                     while line.strip().endswith("\\"):
                         line, comments, new_comments = self._strip_comments(self._get_line(), comments)
+
+                        # Still need to check for parentheses after an escaped line
+                        if "(" in line.split("#")[0] and not self._at_end():
+                            stripped_line = self._strip_syntax(line).strip()
+                            if import_type == "from" and stripped_line and " " not in stripped_line and new_comments:
+                                nested_comments[stripped_line] = comments[-1]
+                            import_string += self.line_separator + line
+
+                            while not line.strip().endswith(")") and not self._at_end():
+                                line, comments, new_comments = self._strip_comments(self._get_line(), comments)
+                                stripped_line = self._strip_syntax(line).strip()
+                                if import_type == "from" and stripped_line and " " not in stripped_line and new_comments:
+                                    nested_comments[stripped_line] = comments[-1]
+                                import_string += self.line_separator + line
+
                         stripped_line = self._strip_syntax(line).strip()
                         if import_type == "from" and stripped_line and " " not in stripped_line and new_comments:
                             nested_comments[stripped_line] = comments[-1]

--- a/test_isort.py
+++ b/test_isort.py
@@ -2294,6 +2294,7 @@ def test_no_inline_sort():
     assert SortImports(file_contents=test_input, no_inline_sort=False, force_single_line=True).output == expected
     assert SortImports(file_contents=test_input, no_inline_sort=True, force_single_line=True).output == expected
 
+
 def test_relative_import_of_a_module():
     """Imports can be dynamically created (PEP302) and is used by modules such as six.  This test ensures that
     these types of imports are still sorted to the correct type instead of being categorized as local."""
@@ -2316,6 +2317,7 @@ def test_relative_import_of_a_module():
 
     sorted_result = SortImports(file_contents=test_input, force_single_line=True).output
     assert sorted_result == expected_results
+
 
 def test_escaped_parens_sort():
     test_input = ('from foo import \\ \n'

--- a/test_isort.py
+++ b/test_isort.py
@@ -2294,7 +2294,6 @@ def test_no_inline_sort():
     assert SortImports(file_contents=test_input, no_inline_sort=False, force_single_line=True).output == expected
     assert SortImports(file_contents=test_input, no_inline_sort=True, force_single_line=True).output == expected
 
-
 def test_relative_import_of_a_module():
     """Imports can be dynamically created (PEP302) and is used by modules such as six.  This test ensures that
     these types of imports are still sorted to the correct type instead of being categorized as local."""
@@ -2317,3 +2316,11 @@ def test_relative_import_of_a_module():
 
     sorted_result = SortImports(file_contents=test_input, force_single_line=True).output
     assert sorted_result == expected_results
+
+def test_escaped_parens_sort():
+    test_input = ('from foo import \\ \n'
+                  '(a,\n'
+                  'b,\n'
+                  'c)\n')
+    expected = ('from foo import a, b, c\n')
+    assert SortImports(file_contents=test_input).output == expected


### PR DESCRIPTION
Fixes issue #575 