### PR TITLE
Don't attempt to process files we can't open

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -65,9 +65,13 @@ def is_python_file(path):
     if path.endswith('.py'):
         return True
 
-    with open(path, 'rb') as fp:
-        line = fp.readline(100)
-    return bool(shebang_re.match(line))
+    try:
+        with open(path, 'rb') as fp:
+            line = fp.readline(100)
+    except IOError:
+        return False
+    else:
+        return bool(shebang_re.match(line))
 
 
 class SortAttempt(object):

--- a/test_isort.py
+++ b/test_isort.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 
 from isort.isort import SortImports, exists_case_sensitive
+from isort.main import is_python_file
 from isort.settings import WrapModes
 
 SHORT_IMPORT = "from third_party import lib1, lib2, lib3, lib4"
@@ -2326,3 +2327,8 @@ def test_escaped_parens_sort():
                   'c)\n')
     expected = ('from foo import a, b, c\n')
     assert SortImports(file_contents=test_input).output == expected
+
+
+def test_is_python_file_ioerror(tmpdir):
+    does_not_exist = tmpdir.join('fake.txt')
+    assert is_python_file(str(does_not_exist)) is False


### PR DESCRIPTION
If a file does not exist (e.g. a symlink to a file that does not exist yet), don't attempt to sort it.