### PR TITLE
Do not apply line endings twice. (#671)

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -211,7 +211,7 @@ class SortImports(object):
                         return
                     if answer in ('quit', 'q'):
                         sys.exit(1)
-            with io.open(self.file_path, encoding=self.file_encoding, mode='w', newline=self.line_separator) as output_file:
+            with io.open(self.file_path, encoding=self.file_encoding, mode='w', newline='') as output_file:
                 print("Fixing {0}".format(self.file_path))
                 output_file.write(self.output)
 


### PR DESCRIPTION
At least on some occasions, setting `newline` to whatever the line endings currently are can cause Python to replace the `\n`s with whatever you pass in, causing lines to be encoded twice. This leads to CRLF files containing `\r\r\n` sequences in place of `\r\n`.

Fixes issue #671.