### PR TITLE
Use environment markers to define Python2 specific dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 max-line-length = 160
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,6 @@ except ImportError:
 with open('README.rst', 'r') as f:
     readme = f.read()
 
-install_requires = []
-if sys.version_info.major == 2:
-    install_requires = ['futures']
-
 setup(name='isort',
       version='4.3.4',
       description='A Python utility / library to sort Python imports.',
@@ -58,9 +54,8 @@ setup(name='isort',
         'pylama.linter': ['isort = isort.pylama_isort:Linter'],
       },
       packages=['isort'],
-      install_requires=install_requires,
+      install_requires=['futures; python_version < "3.2"'],
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-      extras_require={':python_version=="2.7"': ['futures']},
       cmdclass={'test': PyTest},
       keywords='Refactor, Python, Python2, Python3, Refactoring, Imports, Sort, Clean',
       classifiers=['Development Status :: 6 - Mature',


### PR DESCRIPTION
The "futures" package need only be installed on Python 2. To specify a conditional dependency, setuptools, pip, and wheel support "environment markers". Use this mechanism instead of adding install time logic to the setup.py file.

Allows restoring universal wheel support, allowing a single wheel for all version of Python.

For additional details on wheel support for environment markers, see the documentation at:

https://wheel.readthedocs.io/en/stable/index.html#defining-conditional-dependencies

> Defining conditional dependencies
>
> In wheel, the only way to have conditional dependencies (that might only be needed on certain platforms) is to use environment markers as defined by PEP 426.
>
> ...
>
> As of setuptools 36.2.1, you can pass extras as part of install_requires. The above requirements could thus be written like this:
>
> ```py
> install_requires=[
>     'argparse; python_version=="2.6"',
>     'keyring; extra=="signatures"',
>     'pyxdg; extra=="signatures" and sys_platform!="win32"',
>     'ed25519ll; extra=="faster-signatures"'
> ]
> ```