### PR TITLE
Use dict comprehension instead of a dict() constructor

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -416,8 +416,11 @@ class SortImports(object):
                                 self.remove_imports]
 
             sub_modules = ['{0}.{1}'.format(module, from_import) for from_import in from_imports]
-            as_imports = dict((from_import, "{0} as {1}".format(from_import, self.as_map[sub_module])) for
-                              from_import, sub_module in zip(from_imports, sub_modules) if sub_module in self.as_map)
+            as_imports = {
+                from_import: "{0} as {1}".format(from_import, self.as_map[sub_module])
+                for from_import, sub_module in zip(from_imports, sub_modules)
+                if sub_module in self.as_map
+            }
             if self.config['combine_as_imports'] and not ("*" in from_imports and self.config['combine_star']):
                 for from_import in copy.copy(from_imports):
                     if from_import in as_imports:


### PR DESCRIPTION
The dictionary comprehension syntax is available on all supported Python versions. Dictionary comprehension is modern Python syntax and is always faster than the `dict()` constructor, e.g.:

```
  $ python3 -m timeit 'dict((a, a) for a in range(20))'
  100000 loops, best of 3: 2.16 usec per loop
  $ python3 -m timeit '{a: a for a in range(20)}'
  1000000 loops, best of 3: 0.953 usec per loop
```