### PR TITLE
Skip installing isort when running the "lint" tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,4 @@ commands = python setup.py isort
 basepython = python2.7
 deps = flake8==3.3.0
 commands = flake8
+skip_install = True


### PR DESCRIPTION
isort is not a dependency to install & run flake8. Use the `skip_install` configuration option for a slightly faster build.

For details on skip_install, see:

https://tox.readthedocs.io/en/latest/config.html#confval-skip_install=BOOL