### PR TITLE
Allowed grid mode to fall back to hanging grid

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -503,6 +503,16 @@ class SortImports(object):
 
                     if do_multiline_reformat:
                         import_statement = self._multi_line_reformat(import_start, from_import_section, comments)
+                        if self.config['multi_line_output'] == 0:
+                            self.config['multi_line_output'] = 4
+                            try:
+                                other_import_statement = self._multi_line_reformat(import_start, from_import_section, comments)
+                                if (other_import_statement.count('\n') < import_statement.count('\n')
+                                        or max(len(x)
+                                               for x in import_statement.split('\n')) > self.config['line_length']):
+                                    import_statement = other_import_statement
+                            finally:
+                                self.config['multi_line_output'] = 0
                     if not do_multiline_reformat and len(import_statement) > self.config['line_length']:
                         import_statement = self._wrap(import_statement)
 


### PR DESCRIPTION
When there are very long package or module names, the grid mode sometimes outputs lines longer than line_length.   We now fall back to mode 4 if it's more compact or if mode 0 violates the line_length.