### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
   :alt: Coverage
 
 .. image:: https://img.shields.io/github/license/mashape/apistatus.svg
-    :target: https://pypi.python.org/pypi/hug/
+    :target: https://pypi.org/project/hug/
     :alt: License
 
 .. image:: https://badges.gitter.im/Join%20Chat.svg


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html