### PR TITLE
Support path patterns for known sections to find sub packages

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -222,16 +222,17 @@ class SortImports(object):
 
     @staticmethod
     def _parse_known_pattern(pattern):
-        patterns = [pattern]
-
-        # Expand pattern if identified as a directory and find sub packages
+        """
+        Expand pattern if identified as a directory and return sub packages
+        """
         if pattern.endswith(os.path.sep):
-            for path, dirs, files in os.walk(pattern):
-                path = path[len(pattern):]
-                if os.path.sep in path:
-                    continue
-                if '__init__.py' in files:
-                    patterns.append(path)
+            patterns = [
+                package
+                for package in os.listdir(pattern)
+                if os.path.exists(os.path.join(pattern, package, '__init__.py'))
+            ]
+        else:
+            patterns = [pattern]
 
         return patterns
 

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -41,7 +41,7 @@ from glob import glob
 
 from . import settings
 from .natural import nsorted
-from .pie_slice import OrderedSet, input, itemsview
+from .pie_slice import OrderedSet, input, itemsview, PY2
 
 KNOWN_SECTION_MAPPING = {
     'STDLIB': 'STANDARD_LIBRARY',
@@ -220,16 +220,24 @@ class SortImports(object):
                 print("Fixing {0}".format(self.file_path))
                 output_file.write(self.output)
 
-    @staticmethod
-    def _parse_known_pattern(pattern):
+    def _is_package(self, path):
         """
-        Expand pattern if identified as a directory and return sub packages
+        Evaluates if path is a python package
+        """
+        if PY2:
+            return os.path.exists(os.path.join(path, '__init__.py'))
+        else:
+            return os.path.isdir(path)
+
+    def _parse_known_pattern(self, pattern):
+        """
+        Expand pattern if identified as a directory and return found sub packages
         """
         if pattern.endswith(os.path.sep):
             patterns = [
-                package
-                for package in os.listdir(pattern)
-                if os.path.exists(os.path.join(pattern, package, '__init__.py'))
+                filename
+                for filename in os.listdir(pattern)
+                if self._is_package(os.path.join(pattern, filename))
             ]
         else:
             patterns = [pattern]

--- a/test_isort.py
+++ b/test_isort.py
@@ -812,8 +812,7 @@ def test_known_pattern_path_expansion():
                   "import isort.settings\n"
                   "import this\n"
                   "import os\n")
-    test_output = SortImports(file_contents=test_input,
-    known_first_party=['./', 'this']).output
+    test_output = SortImports(file_contents=test_input, known_first_party=['./', 'this']).output
     assert test_output == ("import os\n"
                            "import sys\n"
                            "\n"

--- a/test_isort.py
+++ b/test_isort.py
@@ -33,6 +33,7 @@ import tempfile
 
 from isort.isort import SortImports, exists_case_sensitive
 from isort.main import is_python_file
+from isort.pie_slice import PY2
 from isort.settings import WrapModes
 
 SHORT_IMPORT = "from third_party import lib1, lib2, lib3, lib4"
@@ -808,16 +809,31 @@ def test_thirdy_party_overrides_standard_section():
 
 def test_known_pattern_path_expansion():
     """Test to ensure patterns ending with path sep gets expanded and nested packages treated as known patterns"""
-    test_input = ("import sys\n"
+    test_input = ("from kate_plugin import isort_plugin\n"
+                  "import sys\n"
                   "import isort.settings\n"
                   "import this\n"
                   "import os\n")
-    test_output = SortImports(file_contents=test_input, known_first_party=['./', 'this']).output
-    assert test_output == ("import os\n"
-                           "import sys\n"
-                           "\n"
-                           "import isort.settings\n"
-                           "import this\n")
+    test_output = SortImports(
+        file_contents=test_input,
+        default_section='THIRDPARTY',
+        known_first_party=['./', 'this']
+    ).output
+    if PY2:
+        assert test_output == ("import os\n"
+                               "import sys\n"
+                               "\n"
+                               "from kate_plugin import isort_plugin\n"
+                               "\n"
+                               "import isort.settings\n"
+                               "import this\n")
+    else:
+        assert test_output == ("import os\n"
+                               "import sys\n"
+                               "\n"
+                               "import isort.settings\n"
+                               "import this\n"
+                               "from kate_plugin import isort_plugin\n")
 
 
 def test_force_single_line_imports():

--- a/test_isort.py
+++ b/test_isort.py
@@ -806,6 +806,21 @@ def test_thirdy_party_overrides_standard_section():
                            "import profile.test\n")
 
 
+def test_known_pattern_path_expansion():
+    """Test to ensure patterns ending with path sep gets expanded and nested packages treated as known patterns"""
+    test_input = ("import sys\n"
+                  "import isort.settings\n"
+                  "import this\n"
+                  "import os\n")
+    test_output = SortImports(file_contents=test_input,
+    known_first_party=['./', 'this']).output
+    assert test_output == ("import os\n"
+                           "import sys\n"
+                           "\n"
+                           "import isort.settings\n"
+                           "import this\n")
+
+
 def test_force_single_line_imports():
     """Test to ensure forcing imports to each have their own line works as expected."""
     test_input = ("from third_party import lib1, lib2, \\\n"


### PR DESCRIPTION
Configured known patterns ending with a path separator gets expanded and replaced with sub packages. Probably solves a few different scenarios like grouping section for packages under path, pointing out first party folder etc.

**Related issues:** (?)
Fixes #347 
Fixes #692

**Example:**
Lets say the repo has a `src` folder with a few parallel packages.
``` sh
$ find .
./src
./src/foo
./src/foo/__init__.py
./src/foo/bar.py
./src/ham
./src/ham/__init__.py
./src/ham/spam.py
```

Instead of manually adding `foo`, `ham`, etc. as first party modules, the following *pattern* ...
``` sh
$ isort -p src/ foo/bar.py
```
... gets automatically expanded, as if you would have ...
``` sh
$ isort -p foo -p ham foo/bar.py
```