### PR TITLE
Pass output to stdout even on skipped files

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -117,6 +117,8 @@ class SortImports(object):
         if file_contents is None or ("isort:" + "skip_file") in file_contents:
             self.skipped = True
             self.output = None
+            if write_to_stdout and file_contents:
+                sys.stdout.write(file_contents)
             return
 
         if self.config['line_ending']:


### PR DESCRIPTION
This fixes current behavior where tools that accept output piped from isort sometimes get empty files, which can cause files to be deleted instead of left alone.