### PR TITLE
Don't change Python2 str encoding on import

### DIFF
--- a/isort/__main__.py
+++ b/isort/__main__.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from .pie_slice import apply_changes_to_python_environment
+apply_changes_to_python_environment()
+
 from isort.main import main
 
 main()

--- a/isort/__main__.py
+++ b/isort/__main__.py
@@ -3,6 +3,6 @@ from __future__ import absolute_import
 from .pie_slice import apply_changes_to_python_environment
 apply_changes_to_python_environment()
 
-from isort.main import main
+from isort.main import main  # noqa: E402
 
 main()

--- a/isort/pie_slice.py
+++ b/isort/pie_slice.py
@@ -123,7 +123,10 @@ if PY3:
             return hasattr(entity, '__call__')
         common.append('callable')
 
-    __all__ = common + ['urllib']
+    def apply_changes_to_python_environment():
+        pass
+
+    __all__ = common + ['urllib', 'apply_changes_to_python_environment']
 else:
     from itertools import ifilter as filter  # noqa: F401
     from itertools import imap as map  # noqa: F401
@@ -139,10 +142,6 @@ else:
     import sys
     stdout = sys.stdout
     stderr = sys.stderr
-    reload(sys)
-    sys.stdout = stdout
-    sys.stderr = stderr
-    sys.setdefaultencoding('utf-8')
 
     def _create_not_allowed(name):
         def _not_allow(*args, **kwargs):
@@ -150,8 +149,22 @@ else:
         _not_allow.__name__ = name
         return _not_allow
 
-    for removed in ('apply', 'cmp', 'coerce', 'execfile', 'raw_input', 'unpacks'):
-        globals()[removed] = _create_not_allowed(removed)
+    python_environment_changes_applied = False
+
+    def apply_changes_to_python_environment():
+        global python_environment_changes_applied
+        if python_environment_changes_applied:
+            return
+
+        reload(sys)
+        sys.stdout = stdout
+        sys.stderr = stderr
+        sys.setdefaultencoding('utf-8')
+
+        for removed in ('apply', 'cmp', 'coerce', 'execfile', 'raw_input', 'unpacks'):
+            globals()[removed] = _create_not_allowed(removed)
+
+        python_environment_changes_applied = True
 
     def u(s):
         if isinstance(s, unicode):


### PR DESCRIPTION
isort has a Python3 compatibility module that, among other things, changes the Python environment when imported. These changes aren't restricted to the module importing though; they apply to all code running in the environment.

This is fine when executing isort as a command. However, this leads to weird issues when isort is used as a library, e.g. pytest-isort, because once loaded, it changes the behaviour of Python from that point onwards.

This led to an interesting issue where, depending on if pytest-isort (which imports isort) is installed, UnicodeDecodeErrors are or aren't raised on Python 2.7 due to the sys.setdefaultencoding call. See https://github.com/moccu/pytest-isort/issues/10

I don't think isort should be changing the Python environment through the simple act of importing the code - it's totally unexpected.

In this PR, I've extracted the code that changes the Python environment into a separate function that's only called if isort is executed as a command.

An unfortunate side-effect of this PR is that for some users, this may lead to new exceptions now that the default encoding is no longer being changed (arguably it should not be changed at all - https://stackoverflow.com/questions/3828723/why-should-we-not-use-sys-setdefaultencodingutf-8-in-a-py-script).