### PR TITLE
requirements.txt and Pipfile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+__pycache__
 .DS_Store
 # C extensions
 *.so
@@ -25,6 +26,7 @@ npm-debug.log
 
 # Unit test / coverage reports
 .coverage
+.pytest_cache
 .tox
 nosetests.xml
 htmlcov

--- a/README.rst
+++ b/README.rst
@@ -86,11 +86,23 @@ Installing isort is as simple as:
 
     pip install isort
 
-or if you prefer
+Install isort with requirements.txt support:
 
 .. code-block:: bash
 
-    easy_install isort
+    pip install isort[requirements]
+
+Install isort with Pipfile support:
+
+.. code-block:: bash
+
+    pip install isort[pipfile]
+
+Install isort with both formats support:
+
+.. code-block:: bash
+
+    pip install isort[requirements,pipfile]
 
 Using isort
 ===========

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -184,15 +184,17 @@ class RequirementsFinder(BaseFinder):
     def _get_names(self, path):
         requirements = parse_requirements(path, session=PipSession())
         for req in requirements:
-            yield req.name
+            if req.name:
+                yield req.name
 
     def find(self, module_name):
         module_name, _sep, _submodules = module_name.partition('.')
         module_name = module_name.lower()
+        if not module_name:
+            return
 
         for path in self._get_files():
             for name in self._get_names(path):
-                print(repr(name))
                 if module_name == name.lower():
                     return self.sections.THIRDPARTY
 
@@ -210,7 +212,7 @@ class FindersManager(object):
         PathFinder,
         SetupFinder,
         PipfileFinder,
-        # RequirementsFinder,
+        RequirementsFinder,
         DefaultFinder,
     )
 

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -202,9 +202,9 @@ class RequirementsFinder(BaseFinder):
                 yield req.name
 
     def _normalize_name(self, name):
-        if not self.mapping:
-            return name.lower()
-        return self.mapping.get(name, name).lower()
+        if self.mapping:
+            name = self.mapping.get(name, name)
+        return name.lower().replace('-', '_')
 
     def find(self, module_name):
         # pip not installed yet

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -287,10 +287,9 @@ class PipfileFinder(ReqsBaseFinder):
         with chdir(path):
             project = Pipfile.load(path)
             sections = project.get_sections()
-            if 'packages' not in sections:
-                return
-            for name, version in sections['packages'].items():
-                yield name
+            for section in sections.values():
+                for name in section:
+                    yield name
 
     def _get_files_from_dir(self, path):
         if 'Pipfile' in os.listdir(path):

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -260,7 +260,7 @@ class FindersManager(object):
         LocalFinder,
         KnownPatternFinder,
         PathFinder,
-        # PipfileFinder,
+        PipfileFinder,
         RequirementsFinder,
         DefaultFinder,
     )

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -1,0 +1,169 @@
+"""Finders try to find right section for passed module name
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+import re
+import sys
+import sysconfig
+from fnmatch import fnmatch
+from glob import glob
+
+from .pie_slice import PY2
+from .utils import exists_case_sensitive
+
+
+KNOWN_SECTION_MAPPING = {
+    'STDLIB': 'STANDARD_LIBRARY',
+    'FUTURE': 'FUTURE_LIBRARY',
+    'FIRSTPARTY': 'FIRST_PARTY',
+    'THIRDPARTY': 'THIRD_PARTY',
+}
+
+
+class BaseFinder(object):
+    def __init__(self, config, sections):
+        self.config = config
+        self.sections = sections
+
+
+class ForcedSeparateFinder(BaseFinder):
+    def find(self, module_name):
+        for forced_separate in self.config['forced_separate']:
+            # Ensure all forced_separate patterns will match to end of string
+            path_glob = forced_separate
+            if not forced_separate.endswith('*'):
+                path_glob = '%s*' % forced_separate
+
+            if fnmatch(module_name, path_glob) or fnmatch(module_name, '.' + path_glob):
+                return forced_separate
+
+
+class LocalFinder(BaseFinder):
+    def find(self, module_name):
+        if module_name.startswith("."):
+            return self.sections.LOCALFOLDER
+
+
+class KnownPatternFinder(BaseFinder):
+    def __init__(self, config, sections):
+        super(KnownPatternFinder, self).__init__(config, sections)
+
+        self.known_patterns = []
+        for placement in reversed(self.sections):
+            known_placement = KNOWN_SECTION_MAPPING.get(placement, placement)
+            config_key = 'known_{0}'.format(known_placement.lower())
+            known_patterns = self.config.get(config_key, [])
+            known_patterns = [
+                pattern
+                for known_pattern in known_patterns
+                for pattern in self._parse_known_pattern(known_pattern)
+            ]
+            for known_pattern in known_patterns:
+                regexp = '^' + known_pattern.replace('*', '.*').replace('?', '.?') + '$'
+                self.known_patterns.append((re.compile(regexp), placement))
+
+    @staticmethod
+    def _is_package(path):
+        """
+        Evaluates if path is a python package
+        """
+        if PY2:
+            return os.path.exists(os.path.join(path, '__init__.py'))
+        else:
+            return os.path.isdir(path)
+
+    def _parse_known_pattern(self, pattern):
+        """
+        Expand pattern if identified as a directory and return found sub packages
+        """
+        if pattern.endswith(os.path.sep):
+            patterns = [
+                filename
+                for filename in os.listdir(pattern)
+                if self._is_package(os.path.join(pattern, filename))
+            ]
+        else:
+            patterns = [pattern]
+
+        return patterns
+
+    def find(self, module_name):
+        # Try to find most specific placement instruction match (if any)
+        parts = module_name.split('.')
+        module_names_to_check = ('.'.join(parts[:first_k]) for first_k in range(len(parts), 0, -1))
+        for module_name_to_check in module_names_to_check:
+            for pattern, placement in self.known_patterns:
+                if pattern.match(module_name_to_check):
+                    return placement
+
+
+class PathFinder(BaseFinder):
+    def __init__(self, config, sections):
+        super(PathFinder, self).__init__(config, sections)
+
+        # Use a copy of sys.path to avoid any unintended modifications
+        # to it - e.g. `+=` used below will change paths in place and
+        # if not copied, consequently sys.path, which will grow unbounded
+        # with duplicates on every call to this method.
+        self.paths = list(sys.path)
+        # restore the original import path (i.e. not the path to bin/isort)
+        self.paths[0] = os.getcwd()
+
+        # virtual env
+        self.virtual_env = self.config.get('virtual_env') or os.environ.get('VIRTUAL_ENV')
+        self.virtual_env_src = False
+        if self.virtual_env:
+            self.virtual_env_src = '{0}/src/'.format(self.virtual_env)
+            for path in glob('{0}/lib/python*/site-packages'.format(self.virtual_env)):
+                if path not in self.paths:
+                    self.paths.append(path)
+            for path in glob('{0}/src/*'.format(self.virtual_env)):
+                if os.path.isdir(path):
+                    self.paths.append(path)
+
+        # handle case-insensitive paths on windows
+        self.stdlib_lib_prefix = os.path.normcase(sysconfig.get_paths()['stdlib'])
+
+    def find(self, module_name):
+        for prefix in self.paths:
+            package_path = "/".join((prefix, module_name.split(".")[0]))
+            is_module = (exists_case_sensitive(package_path + ".py") or
+                         exists_case_sensitive(package_path + ".so"))
+            is_package = exists_case_sensitive(package_path) and os.path.isdir(package_path)
+            if is_module or is_package:
+                if 'site-packages' in prefix:
+                    return self.sections.THIRDPARTY
+                if 'dist-packages' in prefix:
+                    return self.sections.THIRDPARTY
+                if self.virtual_env and self.virtual_env_src in prefix:
+                    return self.sections.THIRDPARTY
+                if os.path.normcase(prefix).startswith(self.stdlib_lib_prefix):
+                    return self.sections.STDLIB
+                return self.config['default_section']
+
+
+class DefaultFinder(BaseFinder):
+    def find(self, module_name):
+        return self.config['default_section']
+
+
+class FindersManager(object):
+    finders = (
+        ForcedSeparateFinder,
+        LocalFinder,
+        KnownPatternFinder,
+        PathFinder,
+        DefaultFinder,
+    )
+
+    def __init__(self, config, sections, finders=None):
+        if finders is not None:
+            self.finders = finders
+        self.finders = tuple(finder(config, sections) for finder in self.finders)
+
+    def find(self, module_name):
+        for finder in self.finders:
+            section = finder.find(module_name)
+            if section is not None:
+                return section

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -19,8 +19,11 @@ try:
     from pip._internal.download import PipSession
     from pip._internal.req import parse_requirements
 except ImportError:
-    from pip.download import PipSession
-    from pip.req import parse_requirements
+    try:
+        from pip.download import PipSession
+        from pip.req import parse_requirements
+    except ImportError:
+        parse_requirements = None
 
 
 KNOWN_SECTION_MAPPING = {
@@ -188,6 +191,10 @@ class RequirementsFinder(BaseFinder):
                 yield req.name
 
     def find(self, module_name):
+        # pip not installed yet
+        if not parse_requirements:
+            return
+
         module_name, _sep, _submodules = module_name.partition('.')
         module_name = module_name.lower()
         if not module_name:

--- a/isort/finders.py
+++ b/isort/finders.py
@@ -170,8 +170,9 @@ class ReqsBaseFinder(BaseFinder):
     def __init__(self, config, sections, path='.'):
         super(ReqsBaseFinder, self).__init__(config, sections)
         self.path = path
-        self.mapping = self._load_mapping()
-        self.names = self._load_names()
+        if self.enabled:
+            self.mapping = self._load_mapping()
+            self.names = self._load_names()
 
     @staticmethod
     def _load_mapping():

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -32,23 +32,14 @@ import itertools
 import os
 import re
 import sys
-import sysconfig
 from collections import OrderedDict, namedtuple
 from datetime import datetime
 from difflib import unified_diff
-from fnmatch import fnmatch
-from glob import glob
 
 from . import settings
+from .finders import FindersManager
 from .natural import nsorted
-from .pie_slice import OrderedSet, input, itemsview, PY2
-
-KNOWN_SECTION_MAPPING = {
-    'STDLIB': 'STANDARD_LIBRARY',
-    'FUTURE': 'FUTURE_LIBRARY',
-    'FIRSTPARTY': 'FIRST_PARTY',
-    'THIRDPARTY': 'THIRD_PARTY',
-}
+from .pie_slice import OrderedSet, input, itemsview
 
 
 class SortImports(object):
@@ -147,19 +138,7 @@ class SortImports(object):
         for section in itertools.chain(self.sections, self.config['forced_separate']):
             self.imports[section] = {'straight': OrderedSet(), 'from': OrderedDict()}
 
-        self.known_patterns = []
-        for placement in reversed(self.sections):
-            known_placement = KNOWN_SECTION_MAPPING.get(placement, placement)
-            config_key = 'known_{0}'.format(known_placement.lower())
-            known_patterns = self.config.get(config_key, [])
-            known_patterns = [
-                pattern
-                for known_pattern in known_patterns
-                for pattern in self._parse_known_pattern(known_pattern)
-            ]
-            for known_pattern in known_patterns:
-                self.known_patterns.append((re.compile('^' + known_pattern.replace('*', '.*').replace('?', '.?') + '$'),
-                                            placement))
+        self.finder = FindersManager(config=self.config, sections=self.sections)
 
         self.index = 0
         self.import_index = -1
@@ -222,30 +201,6 @@ class SortImports(object):
                 print("Fixing {0}".format(self.file_path))
                 output_file.write(self.output)
 
-    def _is_package(self, path):
-        """
-        Evaluates if path is a python package
-        """
-        if PY2:
-            return os.path.exists(os.path.join(path, '__init__.py'))
-        else:
-            return os.path.isdir(path)
-
-    def _parse_known_pattern(self, pattern):
-        """
-        Expand pattern if identified as a directory and return found sub packages
-        """
-        if pattern.endswith(os.path.sep):
-            patterns = [
-                filename
-                for filename in os.listdir(pattern)
-                if self._is_package(os.path.join(pattern, filename))
-            ]
-        else:
-            patterns = [pattern]
-
-        return patterns
-
     def _show_diff(self, file_contents):
         for line in unified_diff(
             file_contents.splitlines(1),
@@ -272,59 +227,7 @@ class SortImports(object):
         if it can't determine - it assumes it is project code
 
         """
-        for forced_separate in self.config['forced_separate']:
-            # Ensure all forced_separate patterns will match to end of string
-            path_glob = forced_separate
-            if not forced_separate.endswith('*'):
-                path_glob = '%s*' % forced_separate
-
-            if fnmatch(module_name, path_glob) or fnmatch(module_name, '.' + path_glob):
-                return forced_separate
-
-        if module_name.startswith("."):
-            return self.sections.LOCALFOLDER
-
-        # Try to find most specific placement instruction match (if any)
-        parts = module_name.split('.')
-        module_names_to_check = ['.'.join(parts[:first_k]) for first_k in range(len(parts), 0, -1)]
-        for module_name_to_check in module_names_to_check:
-            for pattern, placement in self.known_patterns:
-                if pattern.match(module_name_to_check):
-                    return placement
-
-        # Use a copy of sys.path to avoid any unintended modifications
-        # to it - e.g. `+=` used below will change paths in place and
-        # if not copied, consequently sys.path, which will grow unbounded
-        # with duplicates on every call to this method.
-        paths = list(sys.path)
-        # restore the original import path (i.e. not the path to bin/isort)
-        paths[0] = os.getcwd()
-        virtual_env = self.config.get('virtual_env') or os.environ.get('VIRTUAL_ENV')
-        virtual_env_src = False
-        if virtual_env:
-            paths += [path for path in glob('{0}/lib/python*/site-packages'.format(virtual_env))
-                      if path not in paths]
-            paths += [path for path in glob('{0}/src/*'.format(virtual_env)) if os.path.isdir(path)]
-            virtual_env_src = '{0}/src/'.format(virtual_env)
-
-        # handle case-insensitive paths on windows
-        stdlib_lib_prefix = os.path.normcase(sysconfig.get_paths()['stdlib'])
-
-        for prefix in paths:
-            package_path = "/".join((prefix, module_name.split(".")[0]))
-            is_module = (exists_case_sensitive(package_path + ".py") or
-                         exists_case_sensitive(package_path + ".so"))
-            is_package = exists_case_sensitive(package_path) and os.path.isdir(package_path)
-            if is_module or is_package:
-                if ('site-packages' in prefix or 'dist-packages' in prefix or
-                        (virtual_env and virtual_env_src in prefix)):
-                    return self.sections.THIRDPARTY
-                elif os.path.normcase(prefix).startswith(stdlib_lib_prefix):
-                    return self.sections.STDLIB
-                else:
-                    return self.config['default_section']
-
-        return self.config['default_section']
+        return self.finder.find(module_name)
 
     def _get_line(self):
         """Returns the current line from the file while incrementing the index."""
@@ -1065,18 +968,3 @@ def coding_check(fname, default='utf-8'):
                 break
 
     return coding
-
-
-def exists_case_sensitive(path):
-    """
-    Returns if the given path exists and also matches the case on Windows.
-
-    When finding files that can be imported, it is important for the cases to match because while
-    file os.path.exists("module.py") and os.path.exists("MODULE.py") both return True on Windows, Python
-    can only import using the case of the real file.
-    """
-    result = os.path.exists(path)
-    if (sys.platform.startswith('win') or sys.platform == 'darwin') and result:
-        directory, basename = os.path.split(path)
-        result = basename in os.listdir(directory)
-    return result

--- a/isort/utils.py
+++ b/isort/utils.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+
+def exists_case_sensitive(path):
+    """
+    Returns if the given path exists and also matches the case on Windows.
+
+    When finding files that can be imported, it is important for the cases to match because while
+    file os.path.exists("module.py") and os.path.exists("MODULE.py") both return True on Windows, Python
+    can only import using the case of the real file.
+    """
+    result = os.path.exists(path)
+    if (sys.platform.startswith('win') or sys.platform == 'darwin') and result:
+        directory, basename = os.path.split(path)
+        result = basename in os.listdir(directory)
+    return result

--- a/isort/utils.py
+++ b/isort/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from contextlib import contextmanager
 
 
 def exists_case_sensitive(path):
@@ -15,3 +16,15 @@ def exists_case_sensitive(path):
         directory, basename = os.path.split(path)
         result = basename in os.listdir(directory)
     return result
+
+
+@contextmanager
+def chdir(path):
+    """Context manager for changing dir and restoring previous workdir after exit.
+    """
+    curdir = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(curdir)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ setup(name='isort',
         'pylama.linter': ['isort = isort.pylama_isort:Linter'],
       },
       packages=['isort'],
+      extra_requires={
+          'requirements': ['pip', 'pipreqs'],
+          'pipfile': ['pip', 'requirementslib'],
+      }
       install_requires=['futures; python_version < "3.2"'],
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name='isort',
       packages=['isort'],
       extra_requires={
           'requirements': ['pip', 'pipreqs'],
-          'pipfile': ['pip', 'requirementslib'],
+          'pipfile': ['pipreqs', 'requirementslib'],
       },
       install_requires=['futures; python_version < "3.2"'],
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(name='isort',
       extra_requires={
           'requirements': ['pip', 'pipreqs'],
           'pipfile': ['pip', 'requirementslib'],
-      }
+      },
       install_requires=['futures; python_version < "3.2"'],
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='isort',
         'pylama.linter': ['isort = isort.pylama_isort:Linter'],
       },
       packages=['isort'],
-      extra_requires={
+      extras_require={
           'requirements': ['pip', 'pipreqs'],
           'pipfile': ['pipreqs', 'requirementslib'],
       },

--- a/test_isort.py
+++ b/test_isort.py
@@ -31,7 +31,8 @@ import shutil
 import sys
 import tempfile
 
-from isort.isort import SortImports, exists_case_sensitive
+from isort.isort import SortImports
+from isort.utils import exists_case_sensitive
 from isort.main import is_python_file
 from isort.pie_slice import PY2
 from isort.settings import WrapModes

--- a/test_isort.py
+++ b/test_isort.py
@@ -2526,7 +2526,7 @@ def test_pipfile_finder(tmpdir):
         path=str(tmpdir)
     )
 
-    assert list(finder._get_names()) == ['Django', 'deal']  # file parsing
+    assert set(finder._get_names()) == {'Django', 'deal'}  # file parsing
 
     assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
     assert finder.find("flask") is None  # package not in reqs

--- a/test_isort.py
+++ b/test_isort.py
@@ -2495,6 +2495,7 @@ def test_requirements_finder(tmpdir):
     assert finder._normalize_name('deal') == 'deal'
     assert finder._normalize_name('Django') == 'django'  # lowercase
     assert finder._normalize_name('django_haystack') == 'haystack'  # mapping
+    assert finder._normalize_name('Flask-RESTful') == 'flask_restful'  # conver `-`to `_`
 
     req_file.remove()
 
@@ -2536,5 +2537,6 @@ def test_pipfile_finder(tmpdir):
     assert finder._normalize_name('deal') == 'deal'
     assert finder._normalize_name('Django') == 'django'  # lowercase
     assert finder._normalize_name('django_haystack') == 'haystack'  # mapping
+    assert finder._normalize_name('Flask-RESTful') == 'flask_restful'  # conver `-`to `_`
 
     pipfile.remove()

--- a/test_isort.py
+++ b/test_isort.py
@@ -2470,32 +2470,35 @@ def test_new_lines_are_preserved():
 
 
 def test_requirements_finder(tmpdir):
+    subdir = tmpdir.mkdir('subdir').join("lol.txt")
+    subdir.write("flask")
     req_file = tmpdir.join('requirements.txt')
     req_file.write(
         "Django==1.11\n"
         "-e git+https://github.com/orsinium/deal.git#egg=deal\n"
     )
     si = SortImports(file_contents="")
-    finder = finders.RequirementsFinder(
-        config=si.config,
-        sections=si.sections,
-        path=str(tmpdir)
-    )
+    for path in (str(tmpdir), str(subdir)):
+        finder = finders.RequirementsFinder(
+            config=si.config,
+            sections=si.sections,
+            path=path
+        )
 
-    files = list(finder._get_files())
-    assert len(files) == 1  # file finding
-    assert files[0].endswith('requirements.txt')  # file finding
-    assert list(finder._get_names(str(req_file))) == ['Django', 'deal']  # file parsing
+        files = list(finder._get_files())
+        assert len(files) == 1  # file finding
+        assert files[0].endswith('requirements.txt')  # file finding
+        assert list(finder._get_names(str(req_file))) == ['Django', 'deal']  # file parsing
 
-    assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
-    assert finder.find("flask") is None  # package not in reqs
-    assert finder.find("deal") == si.sections.THIRDPARTY  # vcs
+        assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
+        assert finder.find("flask") is None  # package not in reqs
+        assert finder.find("deal") == si.sections.THIRDPARTY  # vcs
 
-    assert len(finder.mapping) > 100
-    assert finder._normalize_name('deal') == 'deal'
-    assert finder._normalize_name('Django') == 'django'  # lowercase
-    assert finder._normalize_name('django_haystack') == 'haystack'  # mapping
-    assert finder._normalize_name('Flask-RESTful') == 'flask_restful'  # conver `-`to `_`
+        assert len(finder.mapping) > 100
+        assert finder._normalize_name('deal') == 'deal'
+        assert finder._normalize_name('Django') == 'django'  # lowercase
+        assert finder._normalize_name('django_haystack') == 'haystack'  # mapping
+        assert finder._normalize_name('Flask-RESTful') == 'flask_restful'  # conver `-`to `_`
 
     req_file.remove()
 
@@ -2527,7 +2530,7 @@ def test_pipfile_finder(tmpdir):
         path=str(tmpdir)
     )
 
-    assert set(finder._get_names()) == {'Django', 'deal'}  # file parsing
+    assert set(finder._get_names(str(tmpdir))) == {'Django', 'deal'}  # file parsing
 
     assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
     assert finder.find("flask") is None  # package not in reqs

--- a/test_isort.py
+++ b/test_isort.py
@@ -2485,10 +2485,15 @@ def test_requirements_finder(tmpdir):
     files = list(finder._get_files())
     assert len(files) == 1  # file finding
     assert files[0].endswith('requirements.txt')  # file finding
-    assert list(finder._get_names(str(req_file))) == ['Django', 'deal'] # file parsing
+    assert list(finder._get_names(str(req_file))) == ['Django', 'deal']  # file parsing
 
     assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
     assert finder.find("flask") is None  # package not in reqs
     assert finder.find("deal") == si.sections.THIRDPARTY  # vcs
+
+    assert len(finder.mapping) > 100
+    assert finder._normalize_name('deal') == 'deal'
+    assert finder._normalize_name('Django') == 'django'  # lowercase
+    assert finder._normalize_name('django_haystack') == 'haystack'  # mapping
 
     req_file.remove()

--- a/test_isort.py
+++ b/test_isort.py
@@ -2486,4 +2486,4 @@ def test_requirements_finder(tmpdir):
     assert files[0].endswith('requirements.txt')
     assert list(finder._get_names(str(req_file))) == ['Django', 'deal']
     assert finder.find("django") == si.sections.THIRDPARTY
-    req_file.remove()
+    os.unlink(str(req_file))

--- a/test_isort.py
+++ b/test_isort.py
@@ -2481,9 +2481,14 @@ def test_requirements_finder(tmpdir):
         sections=si.sections,
         path=str(tmpdir)
     )
+
     files = list(finder._get_files())
-    assert len(files) == 1
-    assert files[0].endswith('requirements.txt')
-    assert list(finder._get_names(str(req_file))) == ['Django', 'deal']
-    assert finder.find("django") == si.sections.THIRDPARTY
-    os.unlink(str(req_file))
+    assert len(files) == 1  # file finding
+    assert files[0].endswith('requirements.txt')  # file finding
+    assert list(finder._get_names(str(req_file))) == ['Django', 'deal'] # file parsing
+
+    assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
+    assert finder.find("flask") is None  # package not in reqs
+    assert finder.find("deal") == si.sections.THIRDPARTY  # vcs
+
+    req_file.remove()

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest
     pip
     pipreqs
+    requirementslib
 commands = py.test test_isort.py {posargs}
 
 [testenv:isort-check]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,10 @@ envlist =
     lint
 
 [testenv]
-deps = pytest
+deps =
+    pytest
+    pip
+    pipreqs
 commands = py.test test_isort.py {posargs}
 
 [testenv:isort-check]


### PR DESCRIPTION
1. Split `place_module` to separated classes named "finders". It's make developing and extending easier.
1. Move some operations from "parse_module" stage to "init".
1. Add finder for Pipfile via [requirementslib](https://github.com/sarugaku/requirementslib/) (part of [pipenv](https://github.com/pypa/pipenv/))
1. Add finder for requirements.txt via pip.
1. Both finders (requirements and pipfile) uses [pipreqs](https://github.com/bndr/pipreqs/) for converting PyPI package name to module name.

Fix #459 