### PR TITLE
Remove unnecessary tox -e argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ matrix:
 install:
   - pip install tox
 script:
-  - tox -e $TOXENV
+  - tox


### PR DESCRIPTION
tox already reads the TOXENV environment variable. No need to re-specify
as a command line argument. For details, see:

https://tox.readthedocs.io/en/latest/config.html#confval-envlist=CSV