### PR TITLE
Travis CI and Tox: Add production Python 3.7 to the testing 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: python
 cache: pip
 matrix:
   include:
-  - env: TOXENV=isort-check
+  - python: 3.7
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+    env: TOXENV=isort-check
   - python: 3.7
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ cache: pip
 matrix:
   include:
   - env: TOXENV=isort-check
-  - python: 3.6
+  - python: 3.7
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
     env: TOXENV=lint
   - python: 2.7
     env: TOXENV=py27
@@ -14,6 +16,10 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
+  - python: 3.7
+    env: TOXENV=py37
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
   - python: pypy
     env: TOXENV=pypy
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     isort-check,
-    py27, py34, py35, py36, pypy,
+    py27, py34, py35, py36, py37, pypy,
     lint
 
 [testenv]


### PR DESCRIPTION
* #716 tests pre-release Python 3.7, while this PR attempts to tests with 3.7 production release.
* #719 is also about Python 3.7 but is not related to the testing