### PR TITLE
Tox:  Perform lint test on Python 3

### DIFF
--- a/isort/pie_slice.py
+++ b/isort/pie_slice.py
@@ -133,11 +133,14 @@ else:
     from itertools import izip as zip  # noqa: F401
     from decimal import Decimal, ROUND_HALF_EVEN
 
-    str = unicode
-    chr = unichr
-    input = raw_input
-    range = xrange
-    integer_types = (int, long)
+    try:
+        str = unicode
+        chr = unichr
+        input = raw_input
+        range = xrange
+        integer_types = (int, long)
+    except NameError:  # Python 3
+        sys.exit('This should not happen!')
 
     import sys
     stdout = sys.stdout
@@ -156,10 +159,13 @@ else:
         if python_environment_changes_applied:
             return
 
-        reload(sys)
-        sys.stdout = stdout
-        sys.stderr = stderr
-        sys.setdefaultencoding('utf-8')
+        try:
+            reload(sys)
+            sys.stdout = stdout
+            sys.stderr = stderr
+            sys.setdefaultencoding('utf-8')
+        except NameError:  # Python 3
+            sys.exit('This should not happen!')
 
         for removed in ('apply', 'cmp', 'coerce', 'execfile', 'raw_input', 'unpacks'):
             globals()[removed] = _create_not_allowed(removed)
@@ -167,10 +173,13 @@ else:
         python_environment_changes_applied = True
 
     def u(s):
-        if isinstance(s, unicode):
-            return s
-        else:
-            return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+        try:
+            if isinstance(s, unicode):
+                return s
+            else:
+                return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+        except NameError:  # Python 3
+            return str(s)
 
     def execute(_code_, _globs_=None, _locs_=None):
         """Execute code in a namespace."""

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = py.test test_isort.py {posargs}
 commands = python setup.py isort
 
 [testenv:lint]
-basepython = python2.7
+basepython = python3.6
 deps = flake8==3.5.0
 commands = flake8
 skip_install = True


### PR DESCRIPTION
This is a repeat of #732 which I closed but could not reopen.

This is to assist #716 to migrate testing from Python 3.6 --> 3.7.