### PR TITLE
Make formatting import compatible with black check

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -742,13 +742,17 @@ class SortImports(object):
         return statement
 
     def _output_vertical_hanging_indent(self, statement, imports, white_space, indent, line_length, comments):
+        trailing = ""
+        if len(imports) > 1 and self.config['include_trailing_comma']:
+            trailing = ','
+
         return "{0}({1}{2}{3}{4}{5}{2})".format(
             statement,
             self._add_comments(comments),
             self.line_separator,
             indent,
             ("," + self.line_separator + indent).join(imports),
-            "," if self.config['include_trailing_comma'] else "",
+            trailing,
          )
 
     def _output_vertical_grid_common(self, statement, imports, white_space, indent, line_length, comments,

--- a/test_isort.py
+++ b/test_isort.py
@@ -1272,7 +1272,7 @@ def test_include_trailing_comma():
     ).output
     assert test_output_wrap_single_import_vertical_indent == (
         "from third_party import (\n"
-        "    lib1,\n"
+        "    lib1\n"
         ")\n"
     )
 


### PR DESCRIPTION
When the very long line is met isort should wrap import into one of
multi line outputs. Black says that vertical hanging indent should be
choosen. An for most cases it works correctly. But when only one
import is on the list there is some difference.
Black suggests that there shouldn't be a trailing comma which isort is
giving.