### PR TITLE
explicitly state the section is "isort" and add support for "tool:isort"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,7 +238,7 @@ To configure isort for a single user create a ``~/.isort.cfg`` file:
 Additionally, you can specify project level configuration simply by placing a ``.isort.cfg`` file at the root of your
 project. isort will look up to 25 directories up, from the file it is ran against, to find a project specific configuration.
 
-Or, if you prefer, you can add an isort section to your project's ``setup.cfg`` or ``tox.ini`` file with any desired settings.
+Or, if you prefer, you can add an ``isort`` or ``tool:isort`` section to your project's ``setup.cfg`` or ``tox.ini`` file with any desired settings.
 
 You can then override any of these settings by using command line arguments, or by passing in override values to the
 SortImports class.

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -146,8 +146,8 @@ def from_path(path):
     computed_settings = default.copy()
     _update_settings_with_config(path, '.editorconfig', '~/.editorconfig', ('*', '*.py', '**.py'), computed_settings)
     _update_settings_with_config(path, '.isort.cfg', '~/.isort.cfg', ('settings', 'isort'), computed_settings)
-    _update_settings_with_config(path, 'setup.cfg', None, ('isort', ), computed_settings)
-    _update_settings_with_config(path, 'tox.ini', None, ('isort', ), computed_settings)
+    _update_settings_with_config(path, 'setup.cfg', None, ('isort', 'tool:isort'), computed_settings)
+    _update_settings_with_config(path, 'tox.ini', None, ('isort', 'tool:isort'), computed_settings)
     return computed_settings
 
 


### PR DESCRIPTION
I wasn't sure if the section was explicitly "isort" or something else. I added styling to make that obvious and added support for using "tool:isort" as the section name.