### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 cache: pip
@@ -15,10 +16,9 @@ matrix:
     env: TOXENV=py36
   - python: 3.7
     env: TOXENV=py37
-    dist: xenial
-    sudo: required
   - python: pypy
     env: TOXENV=pypy
+    dist: trusty
 install:
   - pip install tox
 script:


### PR DESCRIPTION
Allows using recent Python versions without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release