### PR TITLE
Remove shebang from isort/main.py

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''  Tool for sorting imports alphabetically, and automatically separated into sections.
 
 Copyright (C) 2013  Timothy Edmund Crosley


### PR DESCRIPTION
Executing isort as script is handled by using either `python -m isort` or the main entry point installed by setuptools. Individual files need not be set as executable.