### PR TITLE
Fix reading quotes in pyproject.toml files

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -262,6 +262,10 @@ def _get_config_data(file_path, sections):
             if config.has_section(section):
                 settings.update(dict(config.items(section)))
 
+        if file_path.endswith('pyproject.toml'):
+            for key in settings.keys():
+                settings[key] = settings[key].strip('"')
+
         return settings
 
     return {}

--- a/test_isort.py
+++ b/test_isort.py
@@ -1868,6 +1868,45 @@ def test_pyproject_conf_file():
         shutil.rmtree(tmp_conf_dir, ignore_errors=True)
 
 
+def test_pyproject_conf_file_strings():
+    """Ensure that quotes do not interfere with string interpretation in pyproject.toml files"""
+    tmp_conf_dir = None
+    conf_file_data = (
+        '[build-system]\n'
+        'requires = ["setuptools", "wheel"]\n'
+        '[tool.poetry]\n'
+        'name = "isort"\n'
+        'version = "0.1.0"\n'
+        'license = "MIT"\n'
+        '[tool.isort]\n'
+        'known_first_party="hashlib"\n'
+        'lines_between_types=1\n'
+        'import_heading_firstparty="My Stuff"\n'
+        'import_heading_stdlib="Standard Library"\n'
+    )
+    test_input = (
+        'import os\n'
+        'import hashlib\n'
+    )
+    correct_output = (
+        '# Standard Library\n'
+        'import os\n'
+        '\n'
+        '# My Stuff\n'
+        'import hashlib\n'
+    )
+
+    try:
+        tmp_conf_dir = tempfile.mkdtemp()
+        tmp_conf_name = os.path.join(tmp_conf_dir, 'pyproject.toml')
+        with codecs.open(tmp_conf_name, 'w') as test_config:
+            test_config.writelines(conf_file_data)
+
+        assert SortImports(file_contents=test_input, settings_path=tmp_conf_dir).output == correct_output
+    finally:
+        shutil.rmtree(tmp_conf_dir, ignore_errors=True)
+
+
 def test_alphabetic_sorting_no_newlines():
     '''Test to ensure that alphabetical sort does not erroneously introduce new lines (issue #328)'''
     test_input = "import os\n"


### PR DESCRIPTION
This fixes the problem described here: https://github.com/timothycrosley/isort/issues/760#issuecomment-449881438