### PR TITLE
Remove unnecessary coerce to dict

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -260,7 +260,7 @@ def _get_config_data(file_path, sections):
         settings = {}
         for section in sections:
             if config.has_section(section):
-                settings.update(dict(config.items(section)))
+                settings.update(config.items(section))
 
         return settings
 


### PR DESCRIPTION
dict.update() can handle the same arguments as dict().