### PR TITLE
Test against latest PyPy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,10 @@ matrix:
     env: TOXENV=py36
   - python: 3.7
     env: TOXENV=py37
-  - python: pypy
+  - python: pypy2.7-6.0
     env: TOXENV=pypy
-    dist: trusty
-  - python: pypy3
+  - python: pypy3.5-6.0
     env: TOXENV=pypy3
-    dist: trusty
 install:
   - pip install tox
 script:


### PR DESCRIPTION
Drops use of 'dist: trusty'.