### PR TITLE
Replace custom OrderedSet class with OrderedDict

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -39,7 +39,7 @@ from difflib import unified_diff
 from . import settings
 from .finders import FindersManager
 from .natural import nsorted
-from .pie_slice import OrderedSet, input, itemsview
+from .pie_slice import input, itemsview
 
 
 class SortImports(object):
@@ -136,7 +136,7 @@ class SortImports(object):
         section_names = self.config['sections']
         self.sections = namedtuple('Sections', section_names)(*[name for name in section_names])
         for section in itertools.chain(self.sections, self.config['forced_separate']):
-            self.imports[section] = {'straight': OrderedSet(), 'from': OrderedDict()}
+            self.imports[section] = {'straight': OrderedDict(), 'from': OrderedDict()}
 
         self.finder = FindersManager(config=self.config, sections=self.sections)
 
@@ -922,10 +922,9 @@ class SortImports(object):
                         if statement_index - 1 == self.import_index:
                             self.import_index -= len(self.comments['above']['from'].get(import_from, []))
 
-                    if root.get(import_from, False):
-                        root[import_from].update(imports)
-                    else:
-                        root[import_from] = OrderedSet(imports)
+                    if import_from not in root:
+                        root[import_from] = OrderedDict()
+                    root[import_from].update((module, None) for module in imports)
                 else:
                     for module in imports:
                         if comments:
@@ -953,7 +952,7 @@ class SortImports(object):
                                 "WARNING: could not place module {0} of line {1} --"
                                 " Do you need to define a default section?".format(import_from, line)
                             )
-                        self.imports[placed_module][import_type].add(module)
+                        self.imports[placed_module][import_type][module] = None
 
 
 def coding_check(fname, default='utf-8'):

--- a/isort/pie_slice.py
+++ b/isort/pie_slice.py
@@ -24,12 +24,6 @@ from __future__ import absolute_import
 import collections
 import sys
 
-try:
-    from collections.abc import MutableSet
-except ImportError:
-    # Python 2.7
-    from collections import MutableSet
-
 __version__ = "1.1.0"
 
 PY2 = sys.version_info[0] == 2
@@ -385,66 +379,3 @@ if sys.version_info < (3, 2):
 
 else:
     from functools import lru_cache  # noqa: F401
-
-
-class OrderedSet(MutableSet):
-
-    def __init__(self, iterable=None):
-        self.end = end = []
-        end += [None, end, end]
-        self.map = {}
-        if iterable is not None:
-            self |= iterable
-
-    def __len__(self):
-        return len(self.map)
-
-    def __contains__(self, key):
-        return key in self.map
-
-    def add(self, key):
-        if key not in self.map:
-            end = self.end
-            curr = end[1]
-            curr[2] = end[1] = self.map[key] = [key, curr, end]
-
-    def discard(self, key):
-        if key in self.map:
-            key, prev, next = self.map.pop(key)
-            prev[2] = next
-            next[1] = prev
-
-    def __iter__(self):
-        end = self.end
-        curr = end[2]
-        while curr is not end:
-            yield curr[0]
-            curr = curr[2]
-
-    def __reversed__(self):
-        end = self.end
-        curr = end[1]
-        while curr is not end:
-            yield curr[0]
-            curr = curr[1]
-
-    def pop(self, last=True):
-        if not self:
-            raise KeyError('set is empty')
-        key = self.end[1][0] if last else self.end[2][0]
-        self.discard(key)
-        return key
-
-    def __repr__(self):
-        if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self))
-
-    def __eq__(self, other):
-        if isinstance(other, OrderedSet):
-            return len(self) == len(other) and list(self) == list(other)
-        return set(self) == set(other)
-
-    def update(self, other):
-        for item in other:
-            self.add(item)


### PR DESCRIPTION
Using just the keys of OrderedDict is enough to simulate an ordered set.
Reduces code complexity, maintenance, and compatibility shims.

Unlike ordered-set, doesn't require an external dependency.