### PR TITLE
Test coverage improvements

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -172,7 +172,7 @@ class ISortCommand(setuptools.Command):
             exit(1)
 
 
-def create_parser():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser(description='Sort Python import definitions alphabetically '
                                                  'within logical sections.')
     inline_args_group = parser.add_mutually_exclusive_group()
@@ -287,14 +287,14 @@ def create_parser():
                         help='Tells isort to apply changes recursively without asking')
     parser.add_argument('files', nargs='*', help='One or more Python source files that need their imports sorted.')
 
-    arguments = {key: value for key, value in vars(parser.parse_args()).items() if value}
+    arguments = {key: value for key, value in vars(parser.parse_args(argv)).items() if value}
     if 'dont_order_by_type' in arguments:
         arguments['order_by_type'] = False
     return arguments
 
 
-def main():
-    arguments = create_parser()
+def main(argv=None):
+    arguments = parse_args(argv)
     if arguments.get('show_version'):
         print(INTRO)
         return

--- a/isort/main.py
+++ b/isort/main.py
@@ -169,7 +169,7 @@ class ISortCommand(setuptools.Command):
                 except IOError as e:
                     print("WARNING: Unable to parse file {0} due to {1}".format(python_file, e))
         if wrong_sorted_files:
-            exit(1)
+            sys.exit(1)
 
 
 def parse_args(argv=None):
@@ -353,7 +353,7 @@ def main(argv=None):
                 except IOError as e:
                     print("WARNING: Unable to parse file {0} due to {1}".format(file_name, e))
         if wrong_sorted_files:
-            exit(1)
+            sys.exit(1)
 
         num_skipped += len(skipped)
         if num_skipped and not arguments.get('quiet', False):

--- a/test_isort.py
+++ b/test_isort.py
@@ -2596,3 +2596,22 @@ def test_monkey_patched_urllib():
         # Previous versions of isort monkey patched urllib which caused unusual
         # importing for other projects.
         from urllib import quote  # noqa: F401
+
+
+def test_argument_parsing():
+    from isort.main import parse_args
+    args = parse_args(['-dt', '-t', 'foo', '--skip=bar', 'baz.py'])
+    assert args['order_by_type'] is False
+    assert args['force_to_top'] == ['foo']
+    assert args['skip'] == ['bar']
+    assert args['files'] == ['baz.py']
+
+
+def test_command_line(tmpdir, capsys):
+    from isort.main import main
+    tmpdir.join("file.py").write("import re\nimport os\n\nimport contextlib\n\n\nimport isort")
+    main(["-rc", str(tmpdir)])
+    assert tmpdir.join("file.py").read() == "import contextlib\nimport os\nimport re\n\nimport isort\n"
+    out, err = capsys.readouterr()
+    assert not err
+    assert str(tmpdir.join("file.py")) in out  # it informs us about fixing

--- a/test_isort.py
+++ b/test_isort.py
@@ -2625,7 +2625,7 @@ def test_command_line(tmpdir, capfd, multiprocess):
     assert str(tmpdir.join("file1.py")) in out
     assert str(tmpdir.join("file2.py")) in out
 
-    
+
 @pytest.mark.parametrize('enabled', (False, True))
 def test_safety_excludes(tmpdir, enabled):
     tmpdir.join("victim.py").write("# ...")

--- a/test_isort.py
+++ b/test_isort.py
@@ -2510,6 +2510,8 @@ def test_new_lines_are_preserved():
     assert n_newline_contents == 'import os\nimport sys\n'
 
 
+@pytest.mark.skipif(not finders.RequirementsFinder.enabled, reason='RequirementsFinder not enabled (too old version of pip?)')
+@pytest.mark.skipif(not finders.pipreqs, reason='pipreqs is missing')
 def test_requirements_finder(tmpdir):
     subdir = tmpdir.mkdir('subdir').join("lol.txt")
     subdir.write("flask")
@@ -2561,6 +2563,8 @@ deal = {editable = true, git = "https://github.com/orsinium/deal.git"}
 """
 
 
+@pytest.mark.skipif(not finders.PipfileFinder.enabled, reason='PipfileFinder not enabled (missing requirementslib?)')
+@pytest.mark.skipif(not finders.pipreqs, reason='pipreqs is missing')
 def test_pipfile_finder(tmpdir):
     pipfile = tmpdir.join('Pipfile')
     pipfile.write(PIPFILE)


### PR DESCRIPTION
* The main.py module had been left mostly untested as far as coverage showed, so this PR adds a test to see that the main bits in there don't smoke an awful lot when plugged in.
* There was needless duplication in the multiprocessing code, which is now neatly DRYed out.  
  In addition, use of `concurrent.futures` (3.2+) was replaced with `multiprocessing` (2.6+). (Not that it matters an awful lot with #782 pending, but still, it felt cleaner like this.)