### PR TITLE
Refuse to work in system/.tox/venv/... directories by default

### DIFF
--- a/isort/main.py
+++ b/isort/main.py
@@ -285,11 +285,16 @@ def create_parser():
                         help='Tells isort to ignore whitespace differences when --check-only is being used.')
     parser.add_argument('-y', '--apply', dest='apply', action='store_true',
                         help='Tells isort to apply changes recursively without asking')
+    parser.add_argument('--unsafe', dest='unsafe', action='store_true',
+                        help='Tells isort to look for files in standard library directories, etc. '
+                             'where it may not be safe to operate in')
     parser.add_argument('files', nargs='*', help='One or more Python source files that need their imports sorted.')
 
     arguments = {key: value for key, value in vars(parser.parse_args()).items() if value}
     if 'dont_order_by_type' in arguments:
         arguments['order_by_type'] = False
+    if arguments.pop('unsafe', False):
+        arguments['safety_excludes'] = False
     return arguments
 
 

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import fnmatch
 import io
 import os
+import re
 import posixpath
 import sys
 import warnings
@@ -47,6 +48,10 @@ except ImportError:
 
 MAX_CONFIG_SEARCH_DEPTH = 25  # The number of parent directories isort will look for a config file within
 DEFAULT_SECTIONS = ('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')
+
+safety_exclude_re = re.compile(
+    r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|lib/python[0-9].[0-9]+)/"
+)
 
 WrapModes = ('GRID', 'VERTICAL', 'HANGING_INDENT', 'VERTICAL_HANGING_INDENT', 'VERTICAL_GRID', 'VERTICAL_GRID_GROUPED',
              'VERTICAL_GRID_GROUPED_NO_COMMA', 'NOQA')
@@ -145,7 +150,9 @@ default = {'force_to_top': [],
            'show_diff': False,
            'ignore_whitespace': False,
            'no_lines_before': [],
-           'no_inline_sort': False}
+           'no_inline_sort': False,
+           'safety_excludes': True,
+           }
 
 
 @lru_cache()
@@ -292,8 +299,13 @@ def _get_config_data(file_path, sections):
 
 def should_skip(filename, config, path='/'):
     """Returns True if the file should be skipped based on the passed in settings."""
+    normalized_path = posixpath.join(path.replace('\\', '/'), filename)
+
+    if config['safety_excludes'] and safety_exclude_re.search(normalized_path):
+        return True
+
     for skip_path in config['skip']:
-        if posixpath.abspath(posixpath.join(path.replace('\\', '/'), filename)) == posixpath.abspath(skip_path.replace('\\', '/')):
+        if posixpath.abspath(normalized_path) == posixpath.abspath(skip_path.replace('\\', '/')):
             return True
 
     position = os.path.split(filename)


### PR DESCRIPTION
This PR makes sure isort won't wander into directories where it shouldn't. By @jdufresne's suggestion, this list is based on that of [Black's](https://github.com/ambv/black/blob/024c9cab55da7bd3236fd88759c9735d6149b464/black.py#L53-L55), with my addition of "lib/pythonX.X", which appears within venvs/site-packages/etc., but should never appear elsewhere.

This behavior can be disabled with the `--unsafe` switch.

Fixes #759