### PR TITLE
Add option for git_hook to modify files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -584,10 +584,11 @@ To cause the commit to fail if there are isort errors (strict mode), include the
     import sys
     from isort.hooks import git_hook
 
-    sys.exit(git_hook(strict=True))
+    sys.exit(git_hook(strict=True, modify=True))
 
 If you just want to display warnings, but allow the commit to happen anyway, call ``git_hook`` without
-the `strict` parameter.
+the `strict` parameter. If you want to display warnings, but not also fix the code, call ``git_hook`` without
+the `modify` parameter.
 
 Setuptools integration
 ----------------------

--- a/isort/hooks.py
+++ b/isort/hooks.py
@@ -48,13 +48,16 @@ def get_lines(command):
     return [line.strip().decode('utf-8') for line in stdout.splitlines()]
 
 
-def git_hook(strict=False):
+def git_hook(strict=False, modify=False):
     """
     Git pre-commit hook to check staged files for isort errors
 
     :param bool strict - if True, return number of errors on exit,
         causing the hook to fail. If False, return zero so it will
         just act as a warning.
+    :param bool modify - if True, fix the sources if they are not 
+        sorted properly. If False, only report result without 
+        modifying anything.
 
     :return number of errors if in strict mode, 0 otherwise.
     """
@@ -78,5 +81,11 @@ def git_hook(strict=False):
 
             if sort.incorrectly_sorted:
                 errors += 1
+                if modify:
+                    SortImports(
+                        file_path=filename, 
+                        file_contents=staged_contents.decode(),
+                        check=False
+                    )
 
     return errors if strict else 0

--- a/isort/hooks.py
+++ b/isort/hooks.py
@@ -3,7 +3,7 @@
 Defines a git hook to allow pre-commit warnings and errors about import order.
 
 usage:
-    exit_code = git_hook(strict=True)
+    exit_code = git_hook(strict=True|False, modify=True|False)
 
 Copyright (C) 2015  Helen Sherwood-Taylor
 
@@ -55,8 +55,8 @@ def git_hook(strict=False, modify=False):
     :param bool strict - if True, return number of errors on exit,
         causing the hook to fail. If False, return zero so it will
         just act as a warning.
-    :param bool modify - if True, fix the sources if they are not 
-        sorted properly. If False, only report result without 
+    :param bool modify - if True, fix the sources if they are not
+        sorted properly. If False, only report result without
         modifying anything.
 
     :return number of errors if in strict mode, 0 otherwise.
@@ -83,9 +83,9 @@ def git_hook(strict=False, modify=False):
                 errors += 1
                 if modify:
                     SortImports(
-                        file_path=filename, 
+                        file_path=filename,
                         file_contents=staged_contents.decode(),
-                        check=False
+                        check=False,
                     )
 
     return errors if strict else 0


### PR DESCRIPTION
With reference to #770, this adds an option to the ``git_hook`` function to allow it to not only display warnings when sources are unsorted, but also fix the sources.

This addition is off by default, so no existing usage will be affected.

I would still argue that ``modify=True`` should be the default, to be in line with the tagline "_isort your python imports for you so you don't have to_". This way, the user doesn't even have to do the sorting, just simply re-staging the files. But I guess this will come at a cost of breaking backwards compatability (hence the per now default of ``modify=False``).