### PR TITLE
Keep trailing comma even for a single from import. Issue 831

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -734,17 +734,13 @@ class SortImports(object):
         line_length: int,
         comments: Sequence[str]
     ) -> str:
-        trailing = ""
-        if len(imports) > 1 and self.config['include_trailing_comma']:
-            trailing = ','
-
         return "{0}({1}{2}{3}{4}{5}{2})".format(
             statement,
             self._add_comments(comments),
             self.line_separator,
             indent,
             ("," + self.line_separator + indent).join(imports),
-            trailing,
+            "," if self.config['include_trailing_comma'] else "",
          )
 
     def _output_vertical_grid_common(

--- a/test_isort.py
+++ b/test_isort.py
@@ -1304,7 +1304,7 @@ def test_include_trailing_comma():
     ).output
     assert test_output_wrap_single_import_vertical_indent == (
         "from third_party import (\n"
-        "    lib1\n"
+        "    lib1,\n"
         ")\n"
     )
 


### PR DESCRIPTION
Commit https://github.com/timothycrosley/isort/commit/75b354995028c66a801c8c0e60f817b60fc64e8e removed commas if there was only one import, ostensibly to conform to Black, but currently Black behavior is such
```
MBP-jpaige% cat test.py
from some.very.lengthy.example.library.that.goes.too.far.subdomain1 import (
    AnObnoxiouslyLongClassName1,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain2 import (
    AnObnoxiouslyLongClassName2,)

from some.very.lengthy.example.library.that.goes.too.far.subdomain3 import (AnObnoxiouslyLongClassName3,)

from some.very.lengthy.example.library.that.goes.too.far.subdomain4 import (AnObnoxiouslyLongClassName4,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain5 import AnObnoxiouslyLongClassName5

from some.very.lengthy.example.library.that.goes.too.far.subdomain6 import (
    AnObnoxiouslyLongClassName6,
    AnObnoxiouslyLongClassName7,
)

from some.library.subdomain7 import (
    AnObnoxiouslyLongClassName8,
    AnObnoxiouslyLongClassName9,
)
MBP-jpaige% python3 -m pip show black
Name: black
Version: 18.9b0
Summary: The uncompromising code formatter.
Home-page: https://github.com/ambv/black
Author: Łukasz Langa
Author-email: lukasz@langa.pl
License: MIT
Location: /usr/local/lib/python3.7/site-packages
Requires: toml, click, attrs, appdirs
Required-by:
MBP-jpaige% python3 -m black test.py
reformatted test.py
All done! ✨ 🍰 ✨
1 file reformatted.
MBP-jpaige% cat test.py
from some.very.lengthy.example.library.that.goes.too.far.subdomain1 import (
    AnObnoxiouslyLongClassName1,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain2 import (
    AnObnoxiouslyLongClassName2,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain3 import (
    AnObnoxiouslyLongClassName3,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain4 import (
    AnObnoxiouslyLongClassName4,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain5 import (
    AnObnoxiouslyLongClassName5,
)

from some.very.lengthy.example.library.that.goes.too.far.subdomain6 import (
    AnObnoxiouslyLongClassName6,
    AnObnoxiouslyLongClassName7,
)

from some.library.subdomain7 import (
    AnObnoxiouslyLongClassName8,
    AnObnoxiouslyLongClassName9,
)
```

And this has been noted in https://github.com/timothycrosley/isort/issues/831