### PR TITLE
Added NOQA to lines to be skipped 

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -263,7 +263,7 @@ class SortImports(object):
     @staticmethod
     def _import_type(line: str) -> Optional[str]:
         """If the current line is an import line it will return its type (from or straight)"""
-        if "isort:skip" in line:
+        if "isort:skip" in line or "NOQA" in line:
             return None
         elif line.startswith('import '):
             return "straight"

--- a/test_isort.py
+++ b/test_isort.py
@@ -2746,3 +2746,22 @@ def test_unwrap_issue_762():
     test_input = ('from os.\\\n'
                   '    path import (join, split)')
     assert SortImports(file_contents=test_input).output == 'from os.path import join, split\n'
+
+
+def test_noqa_issue_679():
+    # Test to ensure that NOQA notation is being observed as expected
+    test_input = ('import os\n'
+                  '\n'
+                  'import requests\n'
+                  'import zed # NOQA\n'
+                  'import ujson # NOQA\n'
+                  '\n'
+                  'import foo')
+    test_output = ('import os\n'
+                   '\n'
+                   'import foo\n'
+                   'import requests\n'
+                   '\n'
+                   'import zed # NOQA\n'
+                   'import ujson # NOQA\n')
+    assert SortImports(file_contents=test_input).output == test_output

--- a/test_isort.py
+++ b/test_isort.py
@@ -2752,7 +2752,7 @@ def test_noqa_issue_679():
     # Test to ensure that NOQA notation is being observed as expected
     test_input = ('import os\n'
                   '\n'
-                  'import requests\n'
+                  'import requestsss\n'
                   'import zed # NOQA\n'
                   'import ujson # NOQA\n'
                   '\n'
@@ -2760,7 +2760,7 @@ def test_noqa_issue_679():
     test_output = ('import os\n'
                    '\n'
                    'import foo\n'
-                   'import requests\n'
+                   'import requestsss\n'
                    '\n'
                    'import zed # NOQA\n'
                    'import ujson # NOQA\n')


### PR DESCRIPTION
Expected behavior is now that all isort:skip and NOQA imports will be moved to bottom, unsorted.