### PR TITLE
Split SortImports class into smaller classes, part 1

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -111,12 +111,7 @@ class SortImports(object):
         if self.config['line_ending']:
             self.line_separator = self.config['line_ending']
         else:
-            if '\r\n' in file_contents:
-                self.line_separator = '\r\n'
-            elif '\r' in file_contents:
-                self.line_separator = '\r'
-            else:
-                self.line_separator = '\n'
+            self.line_separator = utils.infer_line_separator(file_contents)
 
         self.in_lines = file_contents.split(self.line_separator)
         self.original_length = len(self.in_lines)

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -89,7 +89,7 @@ class SortImports(object):
         self.file_path = file_path or ""
         if file_path:
             file_path = os.path.abspath(file_path)
-            if settings.should_skip(file_path, self.config):
+            if settings.file_should_be_skipped(file_path, self.config):
                 self.skipped = True
                 if self.config['verbose']:
                     print("WARNING: {0} was skipped as it's listed in 'skip' setting"

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -114,8 +114,8 @@ class SortImports(object):
             self.line_separator = utils.infer_line_separator(file_contents)
 
         self.in_lines = file_contents.split(self.line_separator)
-        self.original_length = len(self.in_lines)
-        if (self.original_length > 1 or self.in_lines[:1] not in ([], [""])) or self.config['force_adds']:
+        self.original_num_of_lines = len(self.in_lines)
+        if (self.original_num_of_lines > 1 or self.in_lines[:1] not in ([], [""])) or self.config['force_adds']:
             for add_import in self.add_imports:
                 self.in_lines.append(add_import)
         self.number_of_lines = len(self.in_lines)
@@ -139,7 +139,7 @@ class SortImports(object):
         self._parse()
         if self.import_index != -1:
             self._add_formatted_imports()
-        self.length_change = len(self.out_lines) - self.original_length
+        self.length_change = len(self.out_lines) - self.original_num_of_lines
         while self.out_lines and self.out_lines[-1].strip() == "":
             self.out_lines.pop(-1)
         self.out_lines.append("")
@@ -583,7 +583,7 @@ class SortImports(object):
             output.pop(0)
 
         output_at = 0
-        if self.import_index < self.original_length:
+        if self.import_index < self.original_num_of_lines:
             output_at = self.import_index
         elif self._first_comment_index_end != -1 and self._first_comment_index_start <= 2:
             output_at = self._first_comment_index_end

--- a/isort/main.py
+++ b/isort/main.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Iterable, Iterator, List, MutableMapping, Optional
 import setuptools
 
 from isort import SortImports, __version__
-from isort.settings import DEFAULT_SECTIONS, WrapModes, default, from_path, should_skip
+from isort.settings import DEFAULT_SECTIONS, WrapModes, default, from_path, file_should_be_skipped
 
 INTRO = r"""
 /#######################################################################\
@@ -96,7 +96,7 @@ def iter_source_code(paths: Iterable[str], config: MutableMapping[str, Any], ski
 
     for path in paths:
         if os.path.isdir(path):
-            if should_skip(path, config, os.getcwd()):
+            if file_should_be_skipped(path, config, os.getcwd()):
                 skipped.append(path)
                 continue
 
@@ -104,13 +104,13 @@ def iter_source_code(paths: Iterable[str], config: MutableMapping[str, Any], ski
                     path, topdown=True, followlinks=True
             ):
                 for dirname in list(dirnames):
-                    if should_skip(dirname, config, dirpath):
+                    if file_should_be_skipped(dirname, config, dirpath):
                         skipped.append(dirname)
                         dirnames.remove(dirname)
                 for filename in filenames:
                     filepath = os.path.join(dirpath, filename)
                     if is_python_file(filepath):
-                        if should_skip(filename, config, dirpath):
+                        if file_should_be_skipped(filename, config, dirpath):
                             skipped.append(filename)
                         else:
                             yield filepath

--- a/isort/main.py
+++ b/isort/main.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Iterable, Iterator, List, MutableMapping, Optional
 import setuptools
 
 from isort import SortImports, __version__
-from isort.settings import DEFAULT_SECTIONS, WrapModes, default, from_path, file_should_be_skipped
+from isort.settings import DEFAULT_SECTIONS, WrapModes, default, file_should_be_skipped, from_path
 
 INTRO = r"""
 /#######################################################################\

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -363,7 +363,7 @@ def _get_config_data(file_path: str, sections: Iterable[str]) -> Dict[str, Any]:
     return settings
 
 
-def should_skip(
+def file_should_be_skipped(
     filename: str,
     config: Mapping[str, Any],
     path: str = '/'

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -184,6 +184,38 @@ def from_path(path: str) -> Dict[str, Any]:
     return computed_settings
 
 
+def prepare_config(settings_path: str, **setting_overrides: Any) -> Dict[str, Any]:
+    config = from_path(settings_path).copy()
+    for key, value in setting_overrides.items():
+        access_key = key.replace('not_', '').lower()
+        # The sections config needs to retain order and can't be converted to a set.
+        if access_key != 'sections' and type(config.get(access_key)) in (list, tuple):
+            if key.startswith('not_'):
+                config[access_key] = list(set(config[access_key]).difference(value))
+            else:
+                config[access_key] = list(set(config[access_key]).union(value))
+        else:
+            config[key] = value
+
+    if config['force_alphabetical_sort']:
+        config.update({'force_alphabetical_sort_within_sections': True,
+                       'no_sections': True,
+                       'lines_between_types': 1,
+                       'from_first': True})
+
+    indent = str(config['indent'])
+    if indent.isdigit():
+        indent = " " * int(indent)
+    else:
+        indent = indent.strip("'").strip('"')
+        if indent.lower() == "tab":
+            indent = "\t"
+    config['indent'] = indent
+
+    config['comment_prefix'] = config['comment_prefix'].strip("'").strip('"')
+    return config
+
+
 def _update_settings_with_config(
     path: str,
     name: str,

--- a/isort/utils.py
+++ b/isort/utils.py
@@ -52,3 +52,12 @@ def difference(a: Iterable[Any], b: Container[Any]) -> List[Any]:
         if item not in b:
             d.append(item)
     return d
+
+
+def infer_line_separator(file_contents: str) -> str:
+    if '\r\n' in file_contents:
+        return '\r\n'
+    elif '\r' in file_contents:
+        return '\r'
+    else:
+        return '\n'


### PR DESCRIPTION
I want to start working on a https://github.com/timothycrosley/isort/issues/818, but decided to refactor the project a bit to make it a little more extensible. 

Diff ended up being too big, and current develop won't merge cleanly in new branch at all, so I cherry-picked part of it which is mergeable.

And in general, what do you think about it? Is it a good idea? I want to split big `SortImports` object into a number of smaller ones to
1. Reuse parsing logic for function / if-block scoped imports.
2. Make it a little more maintainable, my PyCharm can't even index `isort.py` properly, it's too big and complex. 


