### PR TITLE
Disable requirements based finders

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -315,8 +315,8 @@ class FindersManager(object):
         LocalFinder,
         KnownPatternFinder,
         PathFinder,
-        PipfileFinder,
-        RequirementsFinder,
+        # PipfileFinder,
+        # RequirementsFinder,
         DefaultFinder,
     )
 


### PR DESCRIPTION
Fixes https://github.com/timothycrosley/isort/issues/848.

On Django source code:

isort==4.3.4:
```
$ time isort --quiet --recursive --diff . > isort.out 
5.83user 0.10system 0:05.94elapsed 99%CPU (0avgtext+0avgdata 27760maxresident)k
```

master with those finders enabled:
```
$ time isort --quiet --recursive --diff . > isort.out 
25.82user 2.51system 0:28.43elapsed 99%CPU (0avgtext+0avgdata 51260maxresident)k
```

with those disabled:
```
$ time isort --quiet --recursive --diff . > isort.out 
6.87user 0.13system 0:07.02elapsed 99%CPU (0avgtext+0avgdata 49848maxresident)k
```
20% slowdown from a 4.3.4. should be tolerable, for now, I guess. 

`RequirementsFinder` is the slowest, disabling it alone gives me about 15sec boost on this codebase. In the future, results from finders should probably be cached. 
