### PR TITLE
Add LRU cache to RequirementsFinder._get_names

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -289,10 +289,11 @@ class RequirementsFinder(ReqsBaseFinder):
                         yield full_path
                         break
 
-    def _get_names(self, path: str) -> List[str]:
+    def _get_names(self, path: str) -> Iterator[str]:
         """Load required packages from path to requirements file
         """
-        return RequirementsFinder._get_names_cached(path)
+        for i in RequirementsFinder._get_names_cached(path):
+            yield i
 
     @classmethod
     @lru_cache(maxsize=16)


### PR DESCRIPTION
This caches the result of the function for future invocations with the same
input, which can massively speed up future invocations if they have the same
input as previous calls.

In the case of this function this happens a lot, and each invocation is quite
expensive as the requirements file is parsed every time.

This gives a quite significant performance boost. I've tried running `isort`
with and without this patch on two different applications on Python 3.7.2 and
one one application the run time drops from 12.67 seconds to 1.3 seconds and
on the other it drops from 28.29 seconds to 2.1 seconds.

This optimisation is similiar to the one which was done for the 4.3.x branch
here: https://github.com/timothycrosley/isort/pull/856.