### PR TITLE
Fix test_inconsistent_behavior_in_python_2_and_3_issue_479

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -2243,7 +2243,8 @@ def test_inconsistent_behavior_in_python_2_and_3_issue_479():
     """Test to ensure Python 2 and 3 have the same behavior"""
     test_input = ('from future.standard_library import hooks\n'
                   'from workalendar.europe import UnitedKingdom\n')
-    assert SortImports(file_contents=test_input).output == test_input
+    assert SortImports(file_contents=test_input,
+                       known_first_party=["future"]).output == test_input
 
 
 def test_sort_within_section_comments_issue_436():


### PR DESCRIPTION
This also failed for me with "future" being installed.

Not sure if it makes sense to keep it in the first place, since isort
appears to require py34 now.

Ref: https://github.com/timothycrosley/isort/issues/479#issuecomment-316235116