### PR TITLE
tests: fix default_settings_path

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -68,8 +68,9 @@ def default_settings_path(tmpdir_factory):
     config_file = config_dir.join('.editorconfig').strpath
     with open(config_file, 'w') as editorconfig:
         editorconfig.write(TEST_DEFAULT_CONFIG)
-        os.chdir(config_dir.strpath)
-    return config_dir.strpath
+
+    with config_dir.as_cwd():
+        yield config_dir.strpath
 
 
 def test_happy_path():


### PR DESCRIPTION
Restore `chdir` after tests.

This is relevant for when pytest-cov would display coverage in the end,
and would use absolute paths due to this.