### PR TITLE
Add LRU cache to RequirementsFinder._get_names

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -297,11 +297,20 @@ class RequirementsFinder(ReqsBaseFinder):
     def _get_names(self, path):
         """Load required packages from path to requirements file
         """
+        return RequirementsFinder._get_names_cached(path)
+
+    @classmethod
+    @lru_cache(maxsize=16)
+    def _get_names_cached(cls, path):
+        results = []
+
         with chdir(os.path.dirname(path)):
             requirements = parse_requirements(path, session=PipSession())
             for req in requirements:
                 if req.name:
-                    yield req.name
+                    results.append(req.name)
+
+        return results
 
 
 class PipfileFinder(ReqsBaseFinder):


### PR DESCRIPTION
This should speed up the isort invocations significantly, like what
https://github.com/timothycrosley/isort/pull/856 intended to do, but somehow
missed the mark.

The `_get_names` method of RequirementsFinder seem to be the biggest culprit
and not `_get_files_from_dir`. I think I confused my previous benchmark results
due to `PipfileFinder` and `RequirementsFinder` being enabled in the same
change, so I may potentially have swapped around the benchmark results 🤦‍♂️

---

I would appreciate if somebody else could confirm that this speeds up isort
significantly before it's merged, as I no longer trust my own benchmarking
results.

Also, I have left the caching of `_get_files_from_dir` in as it doesn't seem
to hurt although the performance benefit seems to be negligible.