### PR TITLE
Support integer values for `multi_line_output` from TOML files

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -67,7 +67,7 @@ class WrapModes(enum.Enum):
 
     @staticmethod
     def from_string(value: str) -> 'WrapModes':
-        return getattr(WrapModes, value, None) or WrapModes(int(value))
+        return getattr(WrapModes, str(value), None) or WrapModes(int(value))
 
 
 # Note that none of these lists must be complete as they are simply fallbacks for when included auto-detection fails.


### PR DESCRIPTION
TOML is a typed file format so if you had `multi_line_output = 3` specified in
your `pyproject.toml` file you would get an error like this after the changes
in https://github.com/timothycrosley/isort/pull/860 were merged in:

> TypeError: getattr(): attribute name must be string

This change makes sure the attribute name is a string when passed to `getattr()`
to avoid errors like this going forward.