### PR TITLE
Lookup real path of virtualenv

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -140,6 +140,7 @@ class PathFinder(BaseFinder):
 
         # virtual env
         self.virtual_env = self.config.get('virtual_env') or os.environ.get('VIRTUAL_ENV')
+        self.virtual_env = os.path.realpath(self.virtual_env)
         self.virtual_env_src = False
         if self.virtual_env:
             self.virtual_env_src = '{0}/src/'.format(self.virtual_env)


### PR DESCRIPTION
This ensures we don't get confused and incorrectly classify third party
libraries as first party libraries.

Fixes #876.