### PR TITLE
work on file encoding detection

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -109,8 +109,8 @@ class SortImports(object):
                             " or matches a glob in 'skip_glob' setting".format(file_path))
                     file_contents = None
             if not self.skipped and not file_contents:
-                    with io.open(file_path, 'rb') as f:
-                        file_encoding = coding_check(f)
+                with io.open(file_path, 'rb') as f:
+                    file_encoding = coding_check(f)
                 with io.open(file_path, encoding=file_encoding, newline='') as file_to_import_sort:
                     try:
                         file_contents = file_to_import_sort.read()

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -109,7 +109,6 @@ class SortImports(object):
                             " or matches a glob in 'skip_glob' setting".format(file_path))
                     file_contents = None
             if not self.skipped and not file_contents:
-                elif not file_contents:
                     with io.open(file_path, 'rb') as f:
                         file_encoding = coding_check(f)
                 with io.open(file_path, encoding=file_encoding, newline='') as file_to_import_sort:

--- a/isort/main.py
+++ b/isort/main.py
@@ -326,7 +326,13 @@ def main(argv=None):
 
     file_names = arguments.pop('files', [])
     if file_names == ['-']:
-        SortImports(file_contents=sys.stdin.read(), write_to_stdout=True, **arguments)
+        try:
+            # python 3
+            file_ = sys.stdin.buffer
+        except AttributeError:
+            # python 2
+            file_ = sys.stdin
+        SortImports(file_=file_, write_to_stdout=True, **arguments)
     else:
         if not file_names:
             file_names = ['.']


### PR DESCRIPTION
Here is a proposed patch for #842 that works on Python 2 and Python 3.
Tested with a UTF-8 encoded file and a latin-9 encoded file:
```console
$ isort - < test_utf8.py && echo ok
# coding: utf-8

x = 'testé'
ok
$ isort - < test_latin9.py && echo ok
# coding: latin9

x = 'testé'
ok
```
```console
$ isort test_utf8.py && echo ok
ok
$ isort test_latin9.py && echo ok
ok
```
Also tested with flake8-isort:
```console
$ flake8 --no-isort-config test_utf8.py && echo ok
ok
$ flake8 --no-isort-config test_latin9.py && echo ok
ok
```