### PR TITLE
Do not print file names when in the quiet mode

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -212,7 +212,8 @@ class SortImports(object):
                     if answer in ('quit', 'q'):
                         sys.exit(1)
             with open(self.file_path, 'w', encoding=self.file_encoding, newline='') as output_file:
-                print("Fixing {0}".format(self.file_path))
+                if not self.config['quiet']:
+                    print("Fixing {0}".format(self.file_path))
                 output_file.write(self.output)
 
     @property

--- a/test_isort.py
+++ b/test_isort.py
@@ -2740,6 +2740,22 @@ def test_command_line(tmpdir, capfd, multiprocess):
         assert str(tmpdir.join("file2.py")) in out
 
 
+@pytest.mark.parametrize("quiet", (False, True))
+def test_quiet(tmpdir, capfd, quiet):
+    if sys.platform.startswith("win"):
+        return
+    from isort.main import main
+    tmpdir.join("file1.py").write("import re\nimport os")
+    tmpdir.join("file2.py").write("")
+    arguments = ["-rc", str(tmpdir)]
+    if quiet:
+        arguments.append("-q")
+    main(arguments)
+    out, err = capfd.readouterr()
+    assert not err
+    assert bool(out) != quiet
+
+
 @pytest.mark.parametrize('enabled', (False, True))
 def test_safety_excludes(tmpdir, enabled):
     tmpdir.join("victim.py").write("# ...")


### PR DESCRIPTION
The current help for the `--quiet` option says that it enables "extra
quiet output, only errors are outputted".  However, isort still prints
`Fixing spam/eggs.py` messages to stdout.