### PR TITLE
Make sort case-sensitive

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -304,7 +304,6 @@ class SortImports(object):
                 prefix = "B"
             else:
                 prefix = "C"
-        module_name = module_name.lower()
         if section_name is None or 'length_sort_' + str(section_name).lower() not in config:
             length_sort = config['length_sort']
         else:


### PR DESCRIPTION
Currently, `isort` ignores case when sorting modules. This behavior conflicts with some stricter sorting styles, like i.e. "cryptography" style. This style requires sorting to put upper-case starting modules first, lower-case modules second.
This PR fixes this issue by removing an unnecessary coercion to `.lower()` in `isort`'s core modules sorting routine.