### PR TITLE
Add .pre-commit-hooks.yaml to ensure use with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: isort
+    name: isort
+    entry: isort
+    require_serial: true
+    additional_dependencies: []
+    language: python


### PR DESCRIPTION
Helps isort work as a pre-commit hook with [pre-commit](https://pre-commit.com/)