### PR TITLE
Update the pre-commit configuration for isort

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
     name: isort
     entry: isort
     require_serial: true
-    additional_dependencies: []
     language: python
+    types: [python]


### PR DESCRIPTION
👋 hello, pre-commit maintainer here


A few small things to make this usable elsewhere :)

- `additional_dependencies: []` is the default
- `types: [python]` will limit `isort` to running on python code instead of every file in the repository