### PR TITLE
Fix list passed from toml settings

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -316,6 +316,8 @@ def _update_with_config_file(
 
 
 def _as_list(value: str) -> List[str]:
+    if isinstance(value, list):
+        return [item.strip() for item in value]
     filtered = [
         item.strip()
         for item in value.replace('\n', ',').split(',')


### PR DESCRIPTION
Resolves #923 

When toml is used for config, and especially with the seed-isort-config pre-commit function, the setting gets set to a list of strings, rather than a comma-separated string. This checks that the value passed is already a list and if so strips each item to be safe, and returns that.

This does not update the type-hints in the signature, as the function isn't really supposed to expect a string, but it's just a safeguard in case.