### PR TITLE
Use pip-api instead of importing pip

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -20,15 +20,9 @@ except ImportError:
     pipreqs = None
 
 try:
-    # pip>=10
-    from pip._internal.download import PipSession
-    from pip._internal.req import parse_requirements
+    from pip_api import parse_requirements
 except ImportError:
-    try:
-        from pip.download import PipSession
-        from pip.req import parse_requirements
-    except ImportError:
-        parse_requirements = None
+    parse_requirements = None
 
 try:
     from requirementslib import Pipfile
@@ -325,8 +319,8 @@ class RequirementsFinder(ReqsBaseFinder):
         result = []
 
         with chdir(os.path.dirname(path)):
-            requirements = parse_requirements(path, session=PipSession())
-            for req in requirements:
+            requirements = parse_requirements(path)
+            for req in requirements.values():
                 if req.name:
                     result.append(req.name)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='isort',
       extras_require={
           'pipfile': ['pipreqs', 'requirementslib'],
           'pyproject': ['toml'],
-          'requirements': ['pip', 'pipreqs'],
+          'requirements': ['pip', 'pipreqs', 'pip-api'],
           'xdg_home': ['appdirs>=1.4.0'],
       },
       python_requires=">=3.4",

--- a/test_isort.py
+++ b/test_isort.py
@@ -2578,8 +2578,6 @@ def test_new_lines_are_preserved():
         os.remove(n_newline.name)
 
 
-@pytest.mark.skipif(not finders.RequirementsFinder.enabled, reason='RequirementsFinder not enabled (too old version of pip?)')
-@pytest.mark.skipif(not finders.pipreqs, reason='pipreqs is missing')
 def test_requirements_finder(tmpdir):
     subdir = tmpdir.mkdir('subdir').join("lol.txt")
     subdir.write("flask")
@@ -2656,8 +2654,6 @@ deal = {editable = true, git = "https://github.com/orsinium/deal.git"}
 """
 
 
-@pytest.mark.skipif(not finders.PipfileFinder.enabled, reason='PipfileFinder not enabled (missing requirementslib?)')
-@pytest.mark.skipif(not finders.pipreqs, reason='pipreqs is missing')
 def test_pipfile_finder(tmpdir):
     pipfile = tmpdir.join('Pipfile')
     pipfile.write(PIPFILE)

--- a/test_isort.py
+++ b/test_isort.py
@@ -2597,7 +2597,7 @@ def test_requirements_finder(tmpdir):
         files = list(finder._get_files())
         assert len(files) == 1  # file finding
         assert files[0].endswith('requirements.txt')  # file finding
-        assert list(finder._get_names(str(req_file))) == ['Django', 'deal']  # file parsing
+        assert set(finder._get_names(str(req_file))) == {'Django', 'deal'}  # file parsing
 
         assert finder.find("django") == si.sections.THIRDPARTY  # package in reqs
         assert finder.find("flask") is None  # package not in reqs


### PR DESCRIPTION
Fixes #924.

Also removes some (seemingly?) unnecessary `@pytest.mark.skipif` decorators that were preventing the relevant tests from being run.