### PR TITLE
Add strict_optional = True for some files

### DIFF
--- a/isort/compat.py
+++ b/isort/compat.py
@@ -42,7 +42,7 @@ def read_file_contents(file_path: str, encoding: str, fallback_encoding: str) ->
             return None, None
 
 
-def get_settings_path(settings_path: Optional[str], current_file_path: str) -> str:
+def get_settings_path(settings_path: Optional[str], current_file_path: Optional[str]) -> str:
     if settings_path:
         return settings_path
 

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -193,7 +193,7 @@ class _SortImports(object):
 
     def _add_comments(
         self,
-        comments: Sequence[str],
+        comments: Optional[Sequence[str]],
         original_string: str = ""
     ) -> str:
         """

--- a/isort/natural.py
+++ b/isort/natural.py
@@ -46,6 +46,6 @@ def nsorted(
         key_callback = _natural_keys
     else:
         def key_callback(text: str) -> List[Any]:
-            return _natural_keys(key(text))
+            return _natural_keys(key(text))  # type: ignore
 
     return sorted(to_sort, key=key_callback)

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -38,7 +38,7 @@ from .utils import difference, union
 try:
     import toml
 except ImportError:
-    toml = None
+    toml = None  # type: ignore
 
 try:
     import appdirs

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,15 @@ license_file = LICENSE
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True
-strict_optional = False
+strict_optional = True
 warn_no_return = False
 check_untyped_defs = True
+
+[mypy-test_isort]
+strict_optional = False
+
+[mypy-isort.isort]
+strict_optional = False
 
 [tool:pytest]
 testpaths = test_isort.py


### PR DESCRIPTION
1. `# type: ignore` correspond to mypy bugs.
2. Disabled `strict_optional` for tests because of lots of false positives. 
2. Disabled it for `isort/isort.py` because logic is too involved for me now to fix it fast. After parso move, there'll be no need for it at all. 