### PR TITLE
Fix issue 957

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -242,12 +242,15 @@ class _SortImports(object):
 
                     cont_line = self._wrap(self.config['indent'] + splitter.join(next_line).lstrip())
                     if self.config['use_parentheses']:
-                        output = "{0}{1}({2}{3}{4}{5})".format(
-                            line, splitter, self.line_separator, cont_line,
-                            "," if self.config['include_trailing_comma'] else "",
-                            self.line_separator if wrap_mode in {WrapModes.VERTICAL_HANGING_INDENT,
-                                                                 WrapModes.VERTICAL_GRID_GROUPED}
-                            else "")
+                        if splitter == "as ":
+                            output = "{0}{1}{2}".format(line, splitter, cont_line.lstrip())
+                        else:
+                            output = "{0}{1}({2}{3}{4}{5})".format(
+                                line, splitter, self.line_separator, cont_line,
+                                "," if self.config['include_trailing_comma'] else "",
+                                self.line_separator if wrap_mode in {WrapModes.VERTICAL_HANGING_INDENT,
+                                                                     WrapModes.VERTICAL_GRID_GROUPED}
+                                else "")
                         lines = output.split(self.line_separator)
                         if self.config['comment_prefix'] in lines[-1] and lines[-1].endswith(')'):
                             line, comment = lines[-1].split(self.config['comment_prefix'], 1)

--- a/test_isort.py
+++ b/test_isort.py
@@ -2196,6 +2196,29 @@ def test_alias_using_paren_issue_466():
                        use_parentheses=True).output == expected_output
 
 
+def test_long_alias_using_paren_issue_957():
+    test_input = ('from package import module as very_very_very_very_very_very_very_very_very_very_long_alias\n')
+    expected_output = ('from package import (\n'
+                       '    module as very_very_very_very_very_very_very_very_very_very_long_alias\n'
+                       ')\n')
+    out = SortImports(file_contents=test_input, line_length=50, use_parentheses=True, multi_line_output=WrapModes.VERTICAL_GRID_GROUPED, check=True).output
+    assert out == expected_output
+
+    test_input = ('from deep.deep.deep.deep.deep.deep.deep.deep.deep.package import module as very_very_very_very_very_very_very_very_very_very_long_alias\n')
+    expected_output = ('from deep.deep.deep.deep.deep.deep.deep.deep.deep.package import (\n'
+                       '    module as very_very_very_very_very_very_very_very_very_very_long_alias\n'
+                       ')\n')
+    out = SortImports(file_contents=test_input, line_length=50, use_parentheses=True, multi_line_output=WrapModes.VERTICAL_GRID_GROUPED, check=True).output
+    assert out == expected_output
+
+    test_input = ('from deep.deep.deep.deep.deep.deep.deep.deep.deep.package import very_very_very_very_very_very_very_very_very_very_long_module as very_very_very_very_very_very_very_very_very_very_long_alias\n')
+    expected_output = ('from deep.deep.deep.deep.deep.deep.deep.deep.deep.package import (\n'
+                       '    very_very_very_very_very_very_very_very_very_very_long_module as very_very_very_very_very_very_very_very_very_very_long_alias\n'
+                       ')\n')
+    out = SortImports(file_contents=test_input, line_length=50, use_parentheses=True, multi_line_output=WrapModes.VERTICAL_GRID_GROUPED, check=True).output
+    assert out == expected_output
+
+
 def test_strict_whitespace_by_default(capsys):
     test_input = ('import os\n'
                   'from django.conf import settings\n')


### PR DESCRIPTION
Fix for #957.

```
from package import module as very_very_very_very_very_very_very_very_very_very_long_alias
```
becomes
```
from package import (
     module as very_very_very_very_very_very_very_very_very_very_long_alias
)
```

This will be the output even if the `module as alias` line is longer than the maximum line length. There is another possibly valid output mixing backslashes and parentheses to attempt to stay below the line length:

```
from package import (
     module as \
     very_very_very_very_very_very_very_very_very_very_long_alias
)
```

I haven't implemented that here because it's not obviously better and I want to use `isort` in combination with [black](https://github.com/python/black), which does not use backslashes in this case.
