### PR TITLE
Add NPM node_modules to default exclusion list

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -53,7 +53,7 @@ DEFAULT_SECTIONS = ('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER
 
 safety_exclude_re = re.compile(
     r"/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|\.pants\.d"
-    r"|lib/python[0-9].[0-9]+)/"
+    r"|lib/python[0-9].[0-9]+|node_modules)/"
 )
 
 


### PR DESCRIPTION
Projects frequently have Python and JavaScript coexisting. NPM is the de
facto standard package manager for JavaScript. Ignore third party
packages by default so projects don't need configure this.