### PR TITLE
Specify targeted Python version to mypy

### DIFF
--- a/isort/compat.py
+++ b/isort/compat.py
@@ -95,7 +95,8 @@ class SortImports(object):
             absolute_file_path = resolve(file_path)
             if check_skip:
                 if run_path and run_path in absolute_file_path.parents:
-                    file_name = os.path.relpath(absolute_file_path, run_path)
+                    # TODO: Drop str() when isort is Python 3.6+.
+                    file_name = os.path.relpath(str(absolute_file_path), run_path)
                 else:
                     file_name = str(absolute_file_path)
                     run_path = ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ ignore =
 license_file = LICENSE
 
 [mypy]
+python_version = 3.5
 follow_imports = silent
 ignore_missing_imports = True
 strict_optional = True


### PR DESCRIPTION
Discovered a typing bug where a Path object was passed to
os.path.relpath(), but Path support was not added until Python 3.6.

https://docs.python.org/3/library/os.path.html#os.path.relpath

> Changed in version 3.6: Accepts a path-like object.