### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,9 +10,6 @@ ignore =
     # W504 line break after binary operator
     W504
 
-[metadata]
-license_file = LICENSE
-
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is
deprecated.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include LICENSE, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file