### PR TITLE
Enable mypy warn_no_return in mypy for stricter type checking

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -57,12 +57,14 @@ class ForcedSeparateFinder(BaseFinder):
 
             if fnmatch(module_name, path_glob) or fnmatch(module_name, '.' + path_glob):
                 return forced_separate
+        return None
 
 
 class LocalFinder(BaseFinder):
     def find(self, module_name: str) -> Optional[str]:
         if module_name.startswith("."):
             return self.sections.LOCALFOLDER
+        return None
 
 
 class KnownPatternFinder(BaseFinder):
@@ -106,6 +108,7 @@ class KnownPatternFinder(BaseFinder):
             for pattern, placement in self.known_patterns:
                 if pattern.match(module_name_to_check):
                     return placement
+        return None
 
 
 class PathFinder(BaseFinder):
@@ -176,6 +179,7 @@ class PathFinder(BaseFinder):
                 if os.path.normcase(prefix).startswith(self.stdlib_lib_prefix):
                     return self.sections.STDLIB
                 return self.config['default_section']
+        return None
 
 
 class ReqsBaseFinder(BaseFinder):
@@ -269,6 +273,7 @@ class ReqsBaseFinder(BaseFinder):
         for name in self.names:
             if module_name == name:
                 return self.sections.THIRDPARTY
+        return None
 
 
 class RequirementsFinder(ReqsBaseFinder):
@@ -390,3 +395,4 @@ class FindersManager(object):
                                                                                                        module_name))
             if section is not None:
                 return section
+        return None

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -159,6 +159,7 @@ class _SortImports(object):
             return "straight"
         elif line.startswith('from '):
             return "from"
+        return None
 
     def _at_end(self) -> bool:
         """returns True if we are at the end of the file."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ license_file = LICENSE
 follow_imports = silent
 ignore_missing_imports = True
 strict_optional = True
-warn_no_return = False
 check_untyped_defs = True
 allow_redefinition = True
 


### PR DESCRIPTION
Warns when a function that normally returns a value doesn't. Fixed all
cases discovered by the tool.