### PR TITLE
Add flake8-bugbear to tox.ini lint target

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -2343,7 +2343,7 @@ def test_no_additional_lines_issue_358() -> None:
     ).output
     assert test_output == expected_output
 
-    for attempt in range(5):
+    for _attempt in range(5):
         test_output = SortImports(
             file_contents=test_output,
             multi_line_output=WrapModes.VERTICAL_HANGING_INDENT,
@@ -2387,7 +2387,7 @@ def test_no_additional_lines_issue_358() -> None:
     ).output
     assert test_output == expected_output
 
-    for attempt in range(5):
+    for _attempt in range(5):
         test_output = SortImports(
             file_contents=test_output,
             multi_line_output=WrapModes.VERTICAL_HANGING_INDENT,

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,9 @@ basepython = python3
 commands = python setup.py isort
 
 [testenv:lint]
-deps = flake8
+deps =
+    flake8
+    flake8-bugbear
 commands = flake8
 skip_install = True
 


### PR DESCRIPTION
flake8-bugbear is a plugin for flake8 that can find likely bugs and
design problems. It contains warnings that don't belong in pyflakes and
pycodestyle.

Introduced as this tool is recommended by HOPE-8.