### PR TITLE
CI: Test on Python 3.8 and upgraded PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache: pip
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: TOXENV=py36-coverage
     - python: 3.7
       env: TOXENV=py37-coverage
+    - python: 3.8-dev
+      env: TOXENV=py38-coverage
     - python: pypy3
       env: TOXENV=pypy3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env: TOXENV=py36-coverage
     - python: 3.7
       env: TOXENV=py37-coverage
-    - python: pypy3.5-6.0
+    - python: pypy3
       env: TOXENV=pypy3
     - os: osx
       language: generic

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     isort-check,
     lint,
     mypy,
-    py{35,36,37,py3}
+    py{35,36,37,38,py3}
 
 [testenv]
 deps =


### PR DESCRIPTION
* Test on Python 3.8 beta, to help the beta before 3.8.0 is out, and also confirm isort tests pass on 3.8


* Update PyPy3 from:

```
Python 3.5.3 (fdd60ed87e94, Apr 24 2018, 06:10:04)
[PyPy 6.0.0 with GCC 6.2.0 20160901]
```

to:

```
Python 3.6.1 (784b254d6699, Apr 14 2019, 10:22:42)
[PyPy 7.1.1-beta0 with GCC 6.2.0 20160901]
```

* And Xenial is now the default on Travis

