### PR TITLE
Fix bad sort with force_single_line and sort_within_sections

### DIFF
--- a/test_isort.py
+++ b/test_isort.py
@@ -1066,6 +1066,26 @@ def test_force_single_line_long_imports() -> None:
     )
 
 
+def test_force_single_line_imports_and_sort_within_sections() -> None:
+    test_input = (
+        "from third_party import lib_a, lib_b, lib_d\n"
+        "from third_party.lib_c import lib1\n"
+    )
+    test_output = SortImports(
+        file_contents=test_input,
+        multi_line_output=WrapModes.GRID,
+        line_length=40,
+        force_single_line=True,
+        force_sort_within_sections=True,
+    ).output
+    assert test_output == (
+        "from third_party import lib_a\n"
+        "from third_party import lib_b\n"
+        "from third_party.lib_c import lib1\n"
+        "from third_party import lib_d\n"
+    )
+
+
 def test_titled_imports() -> None:
     """Tests setting custom titled/commented import sections."""
     test_input = (


### PR DESCRIPTION
With both force_single_line and sort_within_sections enabled, modules
are not reliably sorted alphabetically; instead, all imports that
would be combined if force_single_line were false are instead grouped
together, even if another import should (lexicographically) be
somewhere in their midst. The new test case provides a concrete
example.

Also makes a small regex performance enhancement by precompiling
regexes used when force_single_line=True