### PR TITLE
Coding detection closer to PEP 263

### DIFF
--- a/isort/compat.py
+++ b/isort/compat.py
@@ -12,16 +12,16 @@ from isort.isort import _SortImports
 
 def determine_file_encoding(file_path: Path, default: str = "utf-8") -> str:
     # see https://www.python.org/dev/peps/pep-0263/
-    pattern = re.compile(br"coding[:=]\s*([-\w.]+)")
+    pattern = re.compile(br"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 
     coding = default
     with file_path.open("rb") as f:
         for line_number, line in enumerate(f, 1):
+            if line_number > 2:
+                break
             groups = re.findall(pattern, line)
             if groups:
                 coding = groups[0].decode("ascii")
-                break
-            if line_number > 2:
                 break
 
     return coding

--- a/test_isort.py
+++ b/test_isort.py
@@ -2031,6 +2031,28 @@ def test_other_file_encodings(tmpdir) -> None:
         )
 
 
+def test_encoding_not_in_comment(tmpdir) -> None:
+    """Test that 'encoding' not in a comment is ignored"""
+    tmp_fname = tmpdir.join("test_encoding.py")
+    file_contents = "class Foo\n    coding: latin1\n\ns = u'ã'\n".format("utf8")
+    tmp_fname.write_binary(file_contents.encode("utf8"))
+    assert (
+        SortImports(file_path=str(tmp_fname), settings_path=os.getcwd()).output
+        == file_contents
+    )
+
+
+def test_encoding_not_in_first_two_lines(tmpdir) -> None:
+    """Test that 'encoding' not in the first two lines is ignored"""
+    tmp_fname = tmpdir.join("test_encoding.py")
+    file_contents = "\n\n# -*- coding: latin1\n\ns = u'ã'\n".format("utf8")
+    tmp_fname.write_binary(file_contents.encode("utf8"))
+    assert (
+        SortImports(file_path=str(tmp_fname), settings_path=os.getcwd()).output
+        == file_contents
+    )
+
+
 def test_comment_at_top_of_file() -> None:
     """Test to ensure isort correctly handles top of file comments"""
     test_input = (


### PR DESCRIPTION
* Use the regexp from the PEP
* Fix a bug that also checked the third line for coding

Closes #1027 