### PR TITLE
Declare support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     python: 3.7
     env: DEPLOY=yes
   - os: linux
-    python: 3.8-dev
+    python: 3.8
   - os: osx
     language: generic
 script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Python 3.8.0 was released yesterday, so declare support for it.

* https://discuss.python.org/t/python-3-8-0-is-now-available/2478

~Travis CI doesn't yet have 3.8.0 final, but they do have `3.8-dev` which currently points to the release candidate, so is pretty close to the 3.8.0 release, and isort is tested against `3.8-dev`.~

Edit: Travis have _just_ added `3.8`! :)

Here's the Travis tracking issue:

* https://travis-ci.community/t/add-python-3-8-support/5463

AppVeyor will have support in their next images update: https://github.com/appveyor/ci/issues/3142.
