### PR TITLE
Issue #1051: find extension suffixes from importlib.machinery

### DIFF
--- a/isort/finders.py
+++ b/isort/finders.py
@@ -1,4 +1,5 @@
 """Finders try to find right section for passed module name"""
+import importlib.machinery
 import inspect
 import os
 import os.path
@@ -162,9 +163,6 @@ class PathFinder(BaseFinder):
         if self.stdlib_lib_prefix not in self.paths:
             self.paths.append(self.stdlib_lib_prefix)
 
-        # handle compiled libraries
-        self.ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
-
         # add system paths
         for path in sys.path[1:]:
             if path not in self.paths:
@@ -175,8 +173,10 @@ class PathFinder(BaseFinder):
             package_path = "/".join((prefix, module_name.split(".")[0]))
             is_module = (
                 exists_case_sensitive(package_path + ".py")
-                or exists_case_sensitive(package_path + ".so")
-                or exists_case_sensitive(package_path + self.ext_suffix)
+                or any(
+                    exists_case_sensitive(package_path + ext_suffix)
+                    for ext_suffix in importlib.machinery.EXTENSION_SUFFIXES
+                )
                 or exists_case_sensitive(package_path + "/__init__.py")
             )
             is_package = exists_case_sensitive(package_path) and os.path.isdir(package_path)


### PR DESCRIPTION
Thanks for considering my pull request!

This addresses https://github.com/timothycrosley/isort/issues/1051.

In PR https://github.com/timothycrosley/isort/pull/813 earlier this year, I tried to solve a problem with loading compiled extensions by populating an `ext_suffix` instance variable. While my solution worked for OS X and Linux, it unfortunately didn’t work for Windows, where compiled libraries will end with `.pyd` or with an architecture string and `.pyd`.

This PR changes the behavior to use the extension suffixes from Python’s `importlib.machinery` directly.