### PR TITLE
Make it smoother to use with `pre-commit`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
     require_serial: true
     language: python
     types: [python]
+    additional_dependencies: [pipreqs, tomlkit, requirementslib, toml, pip-api]

--- a/README.md
+++ b/README.md
@@ -626,7 +626,19 @@ project.
 Git hook
 --------
 
-isort provides a hook function that can be integrated into your Git
+isort provides [pre-commit](https://pre-commit.com/) hook definition
+so you easily set up a hook to ensure that your imports remain
+sorted. To use it, add something like this to your
+`.pre-commit-config.yaml`.
+
+```yaml
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21-2
+  hooks:
+    - id: isort
+```
+
+isort also ships with a hook function that can be integrated into your Git
 pre-commit script to check Python code before committing.
 
 To cause the commit to fail if there are isort errors (strict mode),


### PR DESCRIPTION
- Add all optional requirements to the `.pre-commit-hooks.yaml` file so that users automatically get pipfile, pyproject, and requirements support.

- Add documentation of the `.pre-commit-hooks.yaml` to the README.