### PR TITLE
Additional vertical multiline option 

### DIFF
--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -273,6 +273,14 @@ def noqa(**interface):
         return f"{retval}{interface['comment_prefix']} NOQA"
 
 
+@_wrap_mode
+def vertical_hanging_indent_bracket(**interface):
+    if not interface["imports"]:
+        return ""
+    statement = vertical_hanging_indent(**interface)
+    return f'{statement[:-1]}{interface["indent"]})'
+
+
 WrapModes = enum.Enum(  # type: ignore
     "WrapModes", {wrap_mode: index for index, wrap_mode in enumerate(_wrap_modes.keys())}
 )


### PR DESCRIPTION
This PR addresses #1093 .

Hi @timothycrosley ,
* implemented the desired functionality.
* named `vertical_hanging_indent_bracket`, hopefully it fits the project's nomenclature
* though this new option would fit better after option `3 - Vertical Hanging Indent`, and be assigned number 4, I added it to the END of the `wrap_modules.py` so that it does not break the API functionality with previous versions (tests wont pass otherwise). It is up to you to decided the best procedure for this.
* PR passes the tests
```
pytest
==== 932 passed, 1 skipped, 56 warnings in 21.48s ====
```

After your comments, before merging, I can update the documentation accordingly.

Cheers,