### PR TITLE
Fixes #1015

### DIFF
--- a/isort/wrap_modes.py
+++ b/isort/wrap_modes.py
@@ -110,8 +110,21 @@ def vertical(**interface):
 def hanging_indent(**interface):
     if not interface["imports"]:
         return ""
-
-    interface["statement"] += interface["imports"].pop(0)
+    next_import = interface["imports"].pop(0)
+    next_statement = interface["statement"] + next_import
+    # Check for first import
+    if len(next_statement) + 3 > interface["line_length"]:
+        next_statement = (
+            comments.add_to_line(
+                interface["comments"],
+                f"{interface['statement']}\\",
+                removed=interface["remove_comments"],
+                comment_prefix=interface["comment_prefix"],
+            )
+            + f"{interface['line_separator']}{interface['indent']}{next_import}"
+        )
+        interface["comments"] = []
+    interface["statement"] = next_statement
     while interface["imports"]:
         next_import = interface["imports"].pop(0)
         next_statement = comments.add_to_line(

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -208,6 +208,23 @@ def test_line_length() -> None:
         == test_input
     )
 
+    # Test Case described in issue #1015
+    test_output = SortImports(
+        file_contents=REALLY_LONG_IMPORT, line_length=25, multi_line_output=WrapModes.HANGING_INDENT
+    ).output
+    assert test_output == (
+        "from third_party import \\\n"
+        "    lib1, lib2, lib3, \\\n"
+        "    lib4, lib5, lib6, \\\n"
+        "    lib7, lib8, lib9, \\\n"
+        "    lib10, lib11, \\\n"
+        "    lib12, lib13, \\\n"
+        "    lib14, lib15, \\\n"
+        "    lib16, lib17, \\\n"
+        "    lib18, lib20, \\\n"
+        "    lib21, lib22\n"
+    )
+
 
 def test_output_modes() -> None:
     """Test setting isort to use various output modes works as expected"""


### PR DESCRIPTION
The first import was directly appended to the statement earlier(probably to prevent extra code for the first coma(',')). Checked the line length on the first import and added a new line if it goes beyond.