### PR TITLE
Lint and test on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: pip cache
         uses: actions/cache@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: pip cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: lint-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            lint-pip-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade poetry
+          poetry install
+
+      - name: Lint
+        run: ./scripts/lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Ubuntu cache
+        uses: actions/cache@v1
+        if: startsWith(matrix.os, 'ubuntu')
+        with:
+          path: ~/.cache/pip
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: macOS cache
+        uses: actions/cache@v1
+        if: startsWith(matrix.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade poetry
+          poetry install
+
+      - name: Test
+        shell: bash
+        run: |
+          poetry run pytest tests/ -s --cov=isort/ --cov=tests/ --cov-report=term-missing ${@-} --cov-report html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Ubuntu cache
         uses: actions/cache@v1


### PR DESCRIPTION
For #1121.

* Add a workflow for linting
  * Only runs on `ubuntu-latest` with Python 3.8
* Add a workflow for `poetry run pytest`
  * Runs on `ubuntu-18.04`, `ubuntu-16.04`, `macos-latest`
  * Maybe a single `ubuntu-latest` would be enough?
  * With Python 3.6-3.8

Examples:

* Lint https://github.com/hugovk/isort/runs/436539359?check_suite_focus=true
* Test https://github.com/hugovk/isort/runs/436539366?check_suite_focus=true

Not included:

* Deploy. This could be done with https://github.com/pypa/gh-action-pypi-publish
* Codecov. Tokenless upload is not yet supported, like with Travis. This either needs the token putting as plaintext in the repo (like https://github.com/pytest-dev/pytest/pull/6441), or waiting a bit longer, they're working on it now (https://github.com/codecov/codecov-action/issues/29#issuecomment-581540357)
* Windows. Omitted for now, the poetry install was failing. As this issue is about replacing Travis and not AppVeyor, that can wait.

For some reason, 3.8 on macOS is failing:

```
>           assert str(tmpdir.join("file1.py")) in out
E           AssertionError: assert '/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0/file1.py' in ''
E            +  where '/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0/file1.py' = str(local('/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0/file1.py'))
E            +    where local('/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0/file1.py') = <bound method LocalPath.join of local('/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0')>('file1.py')
E            +      where <bound method LocalPath.join of local('/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0')> = local('/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pytest-of-runner/pytest-0/test_command_line_True_0').join
```

https://github.com/hugovk/isort/runs/436539509?check_suite_focus=true#step:7:218

Any ideas?