### PR TITLE
Fix config file name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ If you find the default isort settings do not work well for your
 project, isort provides several ways to adjust the behavior.
 
 To configure isort for a single user create a `~/.isort.cfg` or
-`$XDG_CONFIG_HOME/isort.cfg` file:
+`$XDG_CONFIG_HOME/.isort.cfg` file:
 
 ```ini
 [settings]


### PR DESCRIPTION
This PR fixes a config file name on README.

Before: `$XDG_CONFIG_HOME/isort.cfg`
After: `$XDG_CONFIG_HOME/.isort.cfg` (Added a dot) 
