### PR TITLE
Follow-up for #1143

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -3,7 +3,7 @@
 Defines how the default settings for isort should be loaded
 
 (First from the default setting dictionary at the top of the file, then overridden by any settings
- in ~/.isort.cfg or $XDG_CONFIG_HOME/isort.cfg if there are any)
+ in ~/.isort.cfg or $XDG_CONFIG_HOME/.isort.cfg if there are any)
 """
 import configparser
 import fnmatch


### PR DESCRIPTION
Follow-up for #1143.
Fixes another incorrect config file name.