### PR TITLE
Leave appdirs in "darwin" mode

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -33,9 +33,6 @@ except ImportError:
 
 try:
     import appdirs
-
-    if appdirs.system == "darwin":
-        appdirs.system = "linux2"
 except ImportError:
     appdirs = None
 


### PR DESCRIPTION
Thanks for this tool! I'm using it from inside of a Python app (directly importing functions) and after upgrading, I found my `appdirs.system` got set to `"linux2"`. My app also uses `appdirs`, so global override affected my app.

For context, @r-darwish added this override with af92e149151bfd7c637b6691c2b7147c1953953f. And the feature that `appdirs` hasn't implemented yet is https://github.com/ActiveState/appdirs/issues/78.

Would it be okay to just remove the override and leave macOS without XDG_CONFIG_HOME support?

If not, feel free to close (the workaround is easy on my part, just don't import isort until needed when it won't affect the rest of the app).