### PR TITLE
Fix: grid mode wrongly fall back to hanging grid

### DIFF
--- a/isort/isort.py
+++ b/isort/isort.py
@@ -529,7 +529,7 @@ class SortImports(object):
                             try:
                                 other_import_statement = self._multi_line_reformat(import_start, from_import_section, comments)
                                 if (max(len(x)
-                                        for x in import_statement.split('\n')) > self.config['line_length']):
+                                        for x in import_statement.splitlines() > self.config['line_length']):
                                     import_statement = other_import_statement
                             finally:
                                 self.config['multi_line_output'] = 0

--- a/isort/isort.py
+++ b/isort/isort.py
@@ -529,7 +529,7 @@ class SortImports(object):
                             try:
                                 other_import_statement = self._multi_line_reformat(import_start, from_import_section, comments)
                                 if (max(len(x)
-                                        for x in import_statement.splitlines() > self.config['line_length']):
+                                        for x in import_statement.splitlines()) > self.config['line_length']):
                                     import_statement = other_import_statement
                             finally:
                                 self.config['multi_line_output'] = 0


### PR DESCRIPTION
When the line ending is `\r\n` and the line is exact full, this grid mode will be wrongly fall back to hanging grid because \r counts for 1 character.

This conflicts with yapf and will be annoying when hit, because pre-commit will prevent you from submitting commits.