### PR TITLE
speed up docker build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,17 @@
+# project build medadata that can't be used in docker
+Dockerfile
+.appveyor.yml
+.dockerignore
+.pre-commit-hooks.yaml
+.travis.yml
 .git*
+
+# documentation not needed
+CHANGELOG.md
+LICENSE
+MANIFEST.in
+.undertake
+example.gif
+logo.png
+art/
 docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM python:$VERSION
 
 RUN mkdir /isort
 WORKDIR /isort
-COPY . /isort
 
-RUN python3 -m pip install poetry && poetry install
+COPY pyproject.toml poetry.lock /isort/
+RUN python -m pip install --upgrade pip && python -m pip install poetry && poetry install
 
-CMD /isort/scripts/done.sh
+COPY . /isort/
+RUN poetry install
+
+CMD /isort/scripts/test.sh

--- a/docs/contributing/1.-contributing-guide.md
+++ b/docs/contributing/1.-contributing-guide.md
@@ -46,7 +46,10 @@ A local test cycle might look like the following:
 
 1. `docker build ./ -t isort:latest`
 2. `docker run isort`
-3. if #2 fails, debug, save, and goto #1; `docker run -it isort bash` will get you into the failed environment
+3. if #2 fails, debug, save, and goto #1
+    * `docker run -it isort bash` will get you into the failed environment
+    * `docker run -v $(git rev-parse --show-toplevel):/isort` will make changes made in the docker environment persist on your local checkout.
+      **TIP**: combine both to get an interacive docker shell that loads changes made locally, even after build, to quickly rerun that pesky failing test
 4. `./scripts/docker.sh`
 5. if #4 fails, debug, save and goto #1; you may need to specify a different `--build-arg VERSION=$VER`
 6. congrats! you are probably ready to push a contribution


### PR DESCRIPTION
separated dependency installs from isort install in docker which will cache better. Now docker will only download and install external libraries during the first build, unless the lock file is explicitly changed; all subsequent builds will reuse this checkpoint and will only take as long to build as it takes to copy source files.