### PR TITLE
sort_file: Preserve permission bits

### DIFF
--- a/isort/api.py
+++ b/isort/api.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 import textwrap
 from io import StringIO
@@ -479,6 +480,7 @@ def sort_file(
                     with tmp_file.open(
                         "w", encoding=source_file.encoding, newline=""
                     ) as output_stream:
+                        shutil.copymode(filename, tmp_file)
                         changed = sorted_imports(
                             input_stream=source_file.stream,
                             output_stream=output_stream,


### PR DESCRIPTION
isort 4 would overwrite the old file in place, so its permission bits would not be modified.  But as of commit 1920a6c47796bec4ddc2141dbaece6b44a93834e or so, isort instead writes a new file with default permission bits and renames it into place.  So we now need to explicitly copy the permission bits.

Fixes #1194.