### PR TITLE
Fix a typo in poetry config sample

### DIFF
--- a/docs/configuration/config_files.md
+++ b/docs/configuration/config_files.md
@@ -34,7 +34,7 @@ This means other developers will know to look here and you will keep your projec
 The only disadvantage is that other tools you use might not yet support this format, negating the cleanliness.
 
 ```toml
-[tools.isort]
+[tool.isort]
 profile = "hug"
 src_paths = ["isort", "test"]
 ```


### PR DESCRIPTION
Noticed this while trying out `isort` with `black` profile.

Congrats on the release! :)