### PR TITLE
Add Changelog, docs and tests to source tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,14 @@ classifiers = [
     "Topic :: Utilities",
 ]
 urls = { Changelog = "https://github.com/timothycrosley/isort/blob/master/CHANGELOG.md" }
+include = [
+    "CHANGELOG.md",
+    "docs/configuration/*.md",
+    "docs/contributing/*.md",
+    "docs/major_releases/*.md",
+    "docs/quick_start/*.md",
+    "tests/*.py"
+]
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Same as timothycrosley/isort#531 which does no longer work, as now
poetry seems to be used for building the packages