### PR TITLE
Add support for examples in docs

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1,4 +1,5 @@
-Configuration options for isort
+# Configuration options for isort
+
 ========
 
 As a code formatter isort has opinions. However, it also allows you to have your own. If your opinions disagree with those of isort,
@@ -7,19 +8,22 @@ how you want your imports sorted, organized, and formatted.
 
 Too busy to build your perfect isort configuration? For curated common configurations, see isort's [built-in profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/).
 
-
 ## Python Version
-Tells isort to set the known standard library based on the the specified Python version. Default is to assume any Python 3 version could be the target, and use a union off all stdlib modules across versions. If auto is specified, the version of the interpreter used to run isort (currently: 38) will be used.
+
+Tells isort to set the known standard library based on the the specified Python version. Default is to assume any Python 3 version could be the target, and use a union off all stdlib modules across versions. If auto is specified, the version of the interpreter used to run isort (currently: 37) will be used.
 
 **Type:** String  
 **Default:** `py3`  
 **Python & Config File Name:** py_version  
 **CLI Flags:**
 
- - --py
- - --python-version
+- --py
+- --python-version
+
+**No Examples**
 
 ## Force To Top
+
 Force specific imports to the top of their appropriate section.
 
 **Type:** Frozenset  
@@ -27,21 +31,27 @@ Force specific imports to the top of their appropriate section.
 **Python & Config File Name:** force_to_top  
 **CLI Flags:**
 
- - -t
- - --top
+- -t
+- --top
+
+**No Examples**
 
 ## Skip
+
 Files that sort imports should skip over. If you want to skip multiple files you should specify twice: --skip file1 --skip file2.
 
 **Type:** Frozenset  
-**Default:** `frozenset({'buck-out', '.nox', '.mypy_cache', '.venv', 'node_modules', 'dist', '.eggs', 'venv', '.pants.d', '.hg', '_build', 'build', '.tox', '.git'})`  
+**Default:** `('.eggs', '.git', '.hg', '.mypy_cache', '.nox', '.pants.d', '.tox', '.venv', '_build', 'buck-out', 'build', 'dist', 'node_modules', 'venv')`  
 **Python & Config File Name:** skip  
 **CLI Flags:**
 
- - -s
- - --skip
+- -s
+- --skip
+
+**No Examples**
 
 ## Skip Glob
+
 Files that sort imports should skip over.
 
 **Type:** Frozenset  
@@ -49,10 +59,13 @@ Files that sort imports should skip over.
 **Python & Config File Name:** skip_glob  
 **CLI Flags:**
 
- - --sg
- - --skip-glob
+- --sg
+- --skip-glob
+
+**No Examples**
 
 ## Line Length
+
 The max length of an import line (used for wrapping long imports).
 
 **Type:** Int  
@@ -60,12 +73,15 @@ The max length of an import line (used for wrapping long imports).
 **Python & Config File Name:** line_length  
 **CLI Flags:**
 
- - -l
- - -w
- - --line-length
- - --line-width
+- -l
+- -w
+- --line-length
+- --line-width
+
+**No Examples**
 
 ## Wrap Length
+
 Specifies how long lines that are wrapped should be, if not set line_length is used.
 NOTE: wrap_length must be LOWER than or equal to line_length.
 
@@ -74,10 +90,13 @@ NOTE: wrap_length must be LOWER than or equal to line_length.
 **Python & Config File Name:** wrap_length  
 **CLI Flags:**
 
- - --wl
- - --wrap-length
+- --wl
+- --wrap-length
+
+**No Examples**
 
 ## Line Ending
+
 Forces line endings to the specified value. If not set, values will be guessed per-file.
 
 **Type:** String  
@@ -85,10 +104,13 @@ Forces line endings to the specified value. If not set, values will be guessed p
 **Python & Config File Name:** line_ending  
 **CLI Flags:**
 
- - --le
- - --line-ending
+- --le
+- --line-ending
+
+**No Examples**
 
 ## Sections
+
 **No Description**
 
 **Type:** Tuple  
@@ -96,9 +118,12 @@ Forces line endings to the specified value. If not set, values will be guessed p
 **Python & Config File Name:** sections  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## No Sections
+
 Put all imports into the same section bucket
 
 **Type:** Bool  
@@ -106,32 +131,41 @@ Put all imports into the same section bucket
 **Python & Config File Name:** no_sections  
 **CLI Flags:**
 
- - --ds
- - --no-sections
+- --ds
+- --no-sections
+
+**No Examples**
 
 ## Known Future Library
+
 Force isort to recognize a module as part of the future compatibility libraries.
 
 **Type:** Frozenset  
-**Default:** `frozenset({'__future__'})`  
+**Default:** `('__future__',)`  
 **Python & Config File Name:** known_future_library  
 **CLI Flags:**
 
- - -f
- - --future
+- -f
+- --future
+
+**No Examples**
 
 ## Known Third Party
+
 Force isort to recognize a module as being part of a third party library.
 
 **Type:** Frozenset  
-**Default:** `frozenset({'google.appengine.api'})`  
+**Default:** `('google.appengine.api',)`  
 **Python & Config File Name:** known_third_party  
 **CLI Flags:**
 
- - -o
- - --thirdparty
+- -o
+- --thirdparty
+
+**No Examples**
 
 ## Known First Party
+
 Force isort to recognize a module as being part of the current python project.
 
 **Type:** Frozenset  
@@ -139,21 +173,27 @@ Force isort to recognize a module as being part of the current python project.
 **Python & Config File Name:** known_first_party  
 **CLI Flags:**
 
- - -p
- - --project
+- -p
+- --project
+
+**No Examples**
 
 ## Known Standard Library
+
 Force isort to recognize a module as part of Python's standard library.
 
 **Type:** Frozenset  
-**Default:** `frozenset({'imaplib', 'datetime', 'collections', '_dummy_thread', 'email', 'lzma', 'mimetypes', 'statistics', 'tracemalloc', 'os', 'bdb', 'webbrowser', 'pkgutil', 'code', 'textwrap', 'html', 'time', 'shutil', 'cProfile', 'pwd', 'dis', 'modulefinder', 'builtins', 'chunk', 'mmap', 'nntplib', 'heapq', 'socket', 'threading', 'aifc', 'pydoc', 'sndhdr', 'macpath', 'io', 'unittest', 'gc', 'readline', 'ast', 'turtle', 'fractions', 'copy', 'ipaddress', 'asyncio', 'zlib', 'sre_constants', 'plistlib', 'fcntl', 'shlex', 'stringprep', 'cgitb', 'importlib', 'posixpath', 'sqlite3', 'test', 'urllib', 're', 'multiprocessing', 'py_compile', 'typing', 'pyclbr', 'select', 'traceback', 'msvcrt', 'decimal', '_thread', 'enum', 'syslog', 'linecache', 'ssl', 'base64', 'winreg', 'marshal', 'sched', 'codecs', 'errno', 'dbm', 'difflib', 'functools', 'resource', 'unicodedata', 'poplib', 'secrets', 'turtledemo', 'distutils', 'reprlib', 'mailbox', 'pipes', 'zipapp', 'array', 'winsound', 'getpass', 'tokenize', 'crypt', 'curses', 'site', 'csv', 'pickle', 'sysconfig', 'xdrlib', 'zipfile', 'audioop', 'doctest', 'http', 'imghdr', 'ctypes', 'shelve', 'ensurepip', 'math', 'signal', 'colorsys', 'pathlib', 'contextvars', 'runpy', 'profile', 'wave', 'stat', 'calendar', 'copyreg', 'random', 'cmd', 'asyncore', 'tempfile', 'selectors', 'keyword', 'inspect', 'formatter', 'smtpd', 'fileinput', 'tarfile', 'lib2to3', 'xml', 'fpectl', 'asynchat', 'parser', 'cmath', 'xmlrpc', 'json', 'symtable', 'platform', 'types', 'hmac', 'abc', 'ftplib', 'codeop', 'optparse', 'tkinter', 'argparse', 'nis', 'smtplib', 'tabnanny', 'ntpath', 'locale', 'sunau', 'subprocess', 'telnetlib', 'struct', 'binascii', 'configparser', 'compileall', 'quopri', 'rlcompleter', 'pdb', 'token', 'bisect', 'dataclasses', 'zipimport', 'warnings', 'dummy_threading', 'contextlib', 'glob', 'posix', 'tty', 'pickletools', 'trace', 'atexit', 'hashlib', 'concurrent', 'itertools', 'netrc', 'encodings', 'numbers', 'spwd', 'weakref', 'termios', 'ossaudiodev', 'symbol', 'getopt', 'gettext', 'grp', 'bz2', 'faulthandler', 'pty', 'uu', 'queue', 'timeit', 'pstats', 'logging', 'venv', 'socketserver', 'pprint', 'uuid', 'wsgiref', 'filecmp', 'string', 'binhex', 'sys', 'mailcap', 'imp', 'msilib', 'cgi', 'operator', 'fnmatch', 'gzip'})`  
+**Default:** `('_dummy_thread', '_thread', 'abc', 'aifc', 'argparse', 'array', 'ast', 'asynchat', 'asyncio', 'asyncore', 'atexit', 'audioop', 'base64', 'bdb', 'binascii', 'binhex', 'bisect', 'builtins', 'bz2', 'cProfile', 'calendar', 'cgi', 'cgitb', 'chunk', 'cmath', 'cmd', 'code', 'codecs', 'codeop', 'collections', 'colorsys', 'compileall', 'concurrent', 'configparser', 'contextlib', 'contextvars', 'copy', 'copyreg', 'crypt', 'csv', 'ctypes', 'curses', 'dataclasses', 'datetime', 'dbm', 'decimal', 'difflib', 'dis', 'distutils', 'doctest', 'dummy_threading', 'email', 'encodings', 'ensurepip', 'enum', 'errno', 'faulthandler', 'fcntl', 'filecmp', 'fileinput', 'fnmatch', 'formatter', 'fpectl', 'fractions', 'ftplib', 'functools', 'gc', 'getopt', 'getpass', 'gettext', 'glob', 'grp', 'gzip', 'hashlib', 'heapq', 'hmac', 'html', 'http', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io', 'ipaddress', 'itertools', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma', 'macpath', 'mailbox', 'mailcap', 'marshal', 'math', 'mimetypes', 'mmap', 'modulefinder', 'msilib', 'msvcrt', 'multiprocessing', 'netrc', 'nis', 'nntplib', 'ntpath', 'numbers', 'operator', 'optparse', 'os', 'ossaudiodev', 'parser', 'pathlib', 'pdb', 'pickle', 'pickletools', 'pipes', 'pkgutil', 'platform', 'plistlib', 'poplib', 'posix', 'posixpath', 'pprint', 'profile', 'pstats', 'pty', 'pwd', 'py_compile', 'pyclbr', 'pydoc', 'queue', 'quopri', 'random', 're', 'readline', 'reprlib', 'resource', 'rlcompleter', 'runpy', 'sched', 'secrets', 'select', 'selectors', 'shelve', 'shlex', 'shutil', 'signal', 'site', 'smtpd', 'smtplib', 'sndhdr', 'socket', 'socketserver', 'spwd', 'sqlite3', 'sre_constants', 'ssl', 'stat', 'statistics', 'string', 'stringprep', 'struct', 'subprocess', 'sunau', 'symbol', 'symtable', 'sys', 'sysconfig', 'syslog', 'tabnanny', 'tarfile', 'telnetlib', 'tempfile', 'termios', 'test', 'textwrap', 'threading', 'time', 'timeit', 'tkinter', 'token', 'tokenize', 'trace', 'traceback', 'tracemalloc', 'tty', 'turtle', 'turtledemo', 'types', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'venv', 'warnings', 'wave', 'weakref', 'webbrowser', 'winreg', 'winsound', 'wsgiref', 'xdrlib', 'xml', 'xmlrpc', 'zipapp', 'zipfile', 'zipimport', 'zlib')`  
 **Python & Config File Name:** known_standard_library  
 **CLI Flags:**
 
- - -b
- - --builtin
+- -b
+- --builtin
+
+**No Examples**
 
 ## Extra Standard Library
+
 Extra modules to be included in the list of ones in Python's standard library.
 
 **Type:** Frozenset  
@@ -161,9 +201,12 @@ Extra modules to be included in the list of ones in Python's standard library.
 **Python & Config File Name:** extra_standard_library  
 **CLI Flags:**
 
- - --extra-builtin
+- --extra-builtin
+
+**No Examples**
 
 ## Known Other
+
 **No Description**
 
 **Type:** Dict  
@@ -171,9 +214,24 @@ Extra modules to be included in the list of ones in Python's standard library.
 **Python & Config File Name:** known_other  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**Examples:**
+
+No example `.isort.cfg`
+
+### Example `pyproject.toml`
+
+```
+[tool.isort]
+sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'AIRFLOW', 'FIRSTPARTY', 'LOCALFOLDER']
+known_airflow = ['airflow']
+```
+
+No example cli usage
 
 ## Multi Line Output
+
 Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging, 4-vert-grid, 5-vert-grid-grouped, 6-vert-grid-grouped-no-comma).
 
 **Type:** Wrapmodes  
@@ -181,10 +239,13 @@ Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging, 4-vert-grid, 5
 **Python & Config File Name:** multi_line_output  
 **CLI Flags:**
 
- - -m
- - --multi-line
+- -m
+- --multi-line
+
+**No Examples**
 
 ## Forced Separate
+
 **No Description**
 
 **Type:** Tuple  
@@ -192,30 +253,39 @@ Multi line output (0-grid, 1-vertical, 2-hanging, 3-vert-hanging, 4-vert-grid, 5
 **Python & Config File Name:** forced_separate  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Indent
-String to place for indents defaults to "    " (4 spaces).
+
+String to place for indents defaults to " " (4 spaces).
 
 **Type:** String  
-**Default:** `    `  
+**Default:** ``  
 **Python & Config File Name:** indent  
 **CLI Flags:**
 
- - -i
- - --indent
+- -i
+- --indent
+
+**No Examples**
 
 ## Comment Prefix
+
 **No Description**
 
 **Type:** String  
-**Default:** `  #`  
+**Default:** `#`  
 **Python & Config File Name:** comment_prefix  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Length Sort
+
 Sort imports by their string length.
 
 **Type:** Bool  
@@ -223,10 +293,13 @@ Sort imports by their string length.
 **Python & Config File Name:** length_sort  
 **CLI Flags:**
 
- - --ls
- - --length-sort
+- --ls
+- --length-sort
+
+**No Examples**
 
 ## Length Sort Sections
+
 **No Description**
 
 **Type:** Frozenset  
@@ -234,9 +307,12 @@ Sort imports by their string length.
 **Python & Config File Name:** length_sort_sections  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Add Imports
+
 Adds the specified import line to all files, automatically determining correct placement.
 
 **Type:** Frozenset  
@@ -244,10 +320,13 @@ Adds the specified import line to all files, automatically determining correct p
 **Python & Config File Name:** add_imports  
 **CLI Flags:**
 
- - -a
- - --add-import
+- -a
+- --add-import
+
+**No Examples**
 
 ## Remove Imports
+
 Removes the specified import from all files.
 
 **Type:** Frozenset  
@@ -255,10 +334,13 @@ Removes the specified import from all files.
 **Python & Config File Name:** remove_imports  
 **CLI Flags:**
 
- - --rm
- - --remove-import
+- --rm
+- --remove-import
+
+**No Examples**
 
 ## Reverse Relative
+
 Reverse order of relative imports.
 
 **Type:** Bool  
@@ -266,10 +348,13 @@ Reverse order of relative imports.
 **Python & Config File Name:** reverse_relative  
 **CLI Flags:**
 
- - --rr
- - --reverse-relative
+- --rr
+- --reverse-relative
+
+**No Examples**
 
 ## Force Single Line
+
 Forces all from imports to appear on their own line
 
 **Type:** Bool  
@@ -277,10 +362,13 @@ Forces all from imports to appear on their own line
 **Python & Config File Name:** force_single_line  
 **CLI Flags:**
 
- - --sl
- - --force-single-line-imports
+- --sl
+- --force-single-line-imports
+
+**No Examples**
 
 ## Single Line Exclusions
+
 One or more modules to exclude from the single line rule.
 
 **Type:** Tuple  
@@ -288,10 +376,13 @@ One or more modules to exclude from the single line rule.
 **Python & Config File Name:** single_line_exclusions  
 **CLI Flags:**
 
- - --nsl
- - --single-line-exclusions
+- --nsl
+- --single-line-exclusions
+
+**No Examples**
 
 ## Default Section
+
 Sets the default section for imports (by default FIRSTPARTY) options: ('FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER')
 
 **Type:** String  
@@ -299,10 +390,13 @@ Sets the default section for imports (by default FIRSTPARTY) options: ('FUTURE',
 **Python & Config File Name:** default_section  
 **CLI Flags:**
 
- - --sd
- - --section-default
+- --sd
+- --section-default
+
+**No Examples**
 
 ## Import Headings
+
 **No Description**
 
 **Type:** Dict  
@@ -310,9 +404,12 @@ Sets the default section for imports (by default FIRSTPARTY) options: ('FUTURE',
 **Python & Config File Name:** import_headings  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Balanced Wrapping
+
 Balances wrapping to produce the most consistent line length possible
 
 **Type:** Bool  
@@ -320,10 +417,13 @@ Balances wrapping to produce the most consistent line length possible
 **Python & Config File Name:** balanced_wrapping  
 **CLI Flags:**
 
- - -e
- - --balanced
+- -e
+- --balanced
+
+**No Examples**
 
 ## Use Parentheses
+
 Use parenthesis for line continuation on length limit instead of slashes.
 
 **Type:** Bool  
@@ -331,10 +431,13 @@ Use parenthesis for line continuation on length limit instead of slashes.
 **Python & Config File Name:** use_parentheses  
 **CLI Flags:**
 
- - --up
- - --use-parentheses
+- --up
+- --use-parentheses
+
+**No Examples**
 
 ## Order By Type
+
 Order imports by type in addition to alphabetically
 
 **Type:** Bool  
@@ -342,10 +445,13 @@ Order imports by type in addition to alphabetically
 **Python & Config File Name:** order_by_type  
 **CLI Flags:**
 
- - --ot
- - --order-by-type
+- --ot
+- --order-by-type
+
+**No Examples**
 
 ## Atomic
+
 Ensures the output doesn't save if the resulting file contains syntax errors.
 
 **Type:** Bool  
@@ -353,10 +459,13 @@ Ensures the output doesn't save if the resulting file contains syntax errors.
 **Python & Config File Name:** atomic  
 **CLI Flags:**
 
- - --ac
- - --atomic
+- --ac
+- --atomic
+
+**No Examples**
 
 ## Lines After Imports
+
 **No Description**
 
 **Type:** Int  
@@ -364,10 +473,13 @@ Ensures the output doesn't save if the resulting file contains syntax errors.
 **Python & Config File Name:** lines_after_imports  
 **CLI Flags:**
 
- - --lai
- - --lines-after-imports
+- --lai
+- --lines-after-imports
+
+**No Examples**
 
 ## Lines Between Sections
+
 **No Description**
 
 **Type:** Int  
@@ -375,9 +487,12 @@ Ensures the output doesn't save if the resulting file contains syntax errors.
 **Python & Config File Name:** lines_between_sections  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Lines Between Types
+
 **No Description**
 
 **Type:** Int  
@@ -385,10 +500,13 @@ Ensures the output doesn't save if the resulting file contains syntax errors.
 **Python & Config File Name:** lines_between_types  
 **CLI Flags:**
 
- - --lbt
- - --lines-between-types
+- --lbt
+- --lines-between-types
+
+**No Examples**
 
 ## Combine As Imports
+
 Combines as imports on the same line.
 
 **Type:** Bool  
@@ -396,10 +514,13 @@ Combines as imports on the same line.
 **Python & Config File Name:** combine_as_imports  
 **CLI Flags:**
 
- - --ca
- - --combine-as
+- --ca
+- --combine-as
+
+**No Examples**
 
 ## Combine Star
+
 Ensures that if a star import is present, nothing else is imported from that namespace.
 
 **Type:** Bool  
@@ -407,10 +528,13 @@ Ensures that if a star import is present, nothing else is imported from that nam
 **Python & Config File Name:** combine_star  
 **CLI Flags:**
 
- - --cs
- - --combine-star
+- --cs
+- --combine-star
+
+**No Examples**
 
 ## Keep Direct And As Imports
+
 Turns off default behavior that removes direct imports when as imports exist.
 
 **Type:** Bool  
@@ -418,10 +542,13 @@ Turns off default behavior that removes direct imports when as imports exist.
 **Python & Config File Name:** keep_direct_and_as_imports  
 **CLI Flags:**
 
- - -k
- - --keep-direct-and-as
+- -k
+- --keep-direct-and-as
+
+**No Examples**
 
 ## Include Trailing Comma
+
 Includes a trailing comma on multi line imports that include parentheses.
 
 **Type:** Bool  
@@ -429,10 +556,13 @@ Includes a trailing comma on multi line imports that include parentheses.
 **Python & Config File Name:** include_trailing_comma  
 **CLI Flags:**
 
- - --tc
- - --trailing-comma
+- --tc
+- --trailing-comma
+
+**No Examples**
 
 ## From First
+
 Switches the typical ordering preference, showing from imports first then straight ones.
 
 **Type:** Bool  
@@ -440,10 +570,13 @@ Switches the typical ordering preference, showing from imports first then straig
 **Python & Config File Name:** from_first  
 **CLI Flags:**
 
- - --ff
- - --from-first
+- --ff
+- --from-first
+
+**No Examples**
 
 ## Verbose
+
 Shows verbose output, such as when files are skipped or when a check is successful.
 
 **Type:** Bool  
@@ -451,10 +584,13 @@ Shows verbose output, such as when files are skipped or when a check is successf
 **Python & Config File Name:** verbose  
 **CLI Flags:**
 
- - -v
- - --verbose
+- -v
+- --verbose
+
+**No Examples**
 
 ## Quiet
+
 Shows extra quiet output, only errors are outputted.
 
 **Type:** Bool  
@@ -462,10 +598,13 @@ Shows extra quiet output, only errors are outputted.
 **Python & Config File Name:** quiet  
 **CLI Flags:**
 
- - -q
- - --quiet
+- -q
+- --quiet
+
+**No Examples**
 
 ## Force Adds
+
 Forces import adds even if the original file is empty.
 
 **Type:** Bool  
@@ -473,32 +612,40 @@ Forces import adds even if the original file is empty.
 **Python & Config File Name:** force_adds  
 **CLI Flags:**
 
- - --af
- - --force-adds
+- --af
+- --force-adds
+
+**No Examples**
 
 ## Force Alphabetical Sort Within Sections
-Force all imports to be sorted alphabetically within a section
+
+**No Description**
 
 **Type:** Bool  
 **Default:** `False`  
 **Python & Config File Name:** force_alphabetical_sort_within_sections  
 **CLI Flags:**
 
- - --fass
- - --force-alphabetical-sort-within-sections
+- **Not Supported**
+
+**No Examples**
 
 ## Force Alphabetical Sort
-Force all imports to be sorted as a single section
+
+Force all imports to be sorted alphabetically within a section
 
 **Type:** Bool  
 **Default:** `False`  
 **Python & Config File Name:** force_alphabetical_sort  
 **CLI Flags:**
 
- - --fas
- - --force-alphabetical-sort
+- --fass
+- --force-alphabetical-sort-within-sections
+
+**No Examples**
 
 ## Force Grid Wrap
+
 Force number of from imports (defaults to 2) to be grid wrapped regardless of line length
 
 **Type:** Int  
@@ -506,10 +653,13 @@ Force number of from imports (defaults to 2) to be grid wrapped regardless of li
 **Python & Config File Name:** force_grid_wrap  
 **CLI Flags:**
 
- - --fgw
- - --force-grid-wrap
+- --fgw
+- --force-grid-wrap
+
+**No Examples**
 
 ## Force Sort Within Sections
+
 Force imports to be sorted by module, independent of import_type
 
 **Type:** Bool  
@@ -517,10 +667,13 @@ Force imports to be sorted by module, independent of import_type
 **Python & Config File Name:** force_sort_within_sections  
 **CLI Flags:**
 
- - --fss
- - --force-sort-within-sections
+- --fss
+- --force-sort-within-sections
+
+**No Examples**
 
 ## Lexicographical
+
 **No Description**
 
 **Type:** Bool  
@@ -528,9 +681,12 @@ Force imports to be sorted by module, independent of import_type
 **Python & Config File Name:** lexicographical  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Ignore Whitespace
+
 Tells isort to ignore whitespace differences when --check-only is being used.
 
 **Type:** Bool  
@@ -538,10 +694,13 @@ Tells isort to ignore whitespace differences when --check-only is being used.
 **Python & Config File Name:** ignore_whitespace  
 **CLI Flags:**
 
- - --ws
- - --ignore-whitespace
+- --ws
+- --ignore-whitespace
+
+**No Examples**
 
 ## No Lines Before
+
 Sections which should not be split with previous by empty lines
 
 **Type:** Frozenset  
@@ -549,10 +708,13 @@ Sections which should not be split with previous by empty lines
 **Python & Config File Name:** no_lines_before  
 **CLI Flags:**
 
- - --nlb
- - --no-lines-before
+- --nlb
+- --no-lines-before
+
+**No Examples**
 
 ## No Inline Sort
+
 Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c ,b`).
 
 **Type:** Bool  
@@ -560,10 +722,13 @@ Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c 
 **Python & Config File Name:** no_inline_sort  
 **CLI Flags:**
 
- - --nis
- - --no-inline-sort
+- --nis
+- --no-inline-sort
+
+**No Examples**
 
 ## Ignore Comments
+
 **No Description**
 
 **Type:** Bool  
@@ -571,9 +736,12 @@ Leaves `from` imports with multiple imports 'as-is' (e.g. `from foo import a, c 
 **Python & Config File Name:** ignore_comments  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Case Sensitive
+
 Tells isort to include casing when sorting module names
 
 **Type:** Bool  
@@ -581,9 +749,12 @@ Tells isort to include casing when sorting module names
 **Python & Config File Name:** case_sensitive  
 **CLI Flags:**
 
- - --case-sensitive
+- --case-sensitive
+
+**No Examples**
 
 ## Sources
+
 **No Description**
 
 **Type:** Tuple  
@@ -591,9 +762,12 @@ Tells isort to include casing when sorting module names
 **Python & Config File Name:** sources  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Virtual Env
+
 Virtual environment to use for determining whether a package is third-party
 
 **Type:** String  
@@ -601,9 +775,12 @@ Virtual environment to use for determining whether a package is third-party
 **Python & Config File Name:** virtual_env  
 **CLI Flags:**
 
- - --virtual-env
+- --virtual-env
+
+**No Examples**
 
 ## Conda Env
+
 Conda environment to use for determining whether a package is third-party
 
 **Type:** String  
@@ -611,9 +788,12 @@ Conda environment to use for determining whether a package is third-party
 **Python & Config File Name:** conda_env  
 **CLI Flags:**
 
- - --conda-env
+- --conda-env
+
+**No Examples**
 
 ## Ensure Newline Before Comments
+
 Inserts a blank line before a comment following an import.
 
 **Type:** Bool  
@@ -621,10 +801,13 @@ Inserts a blank line before a comment following an import.
 **Python & Config File Name:** ensure_newline_before_comments  
 **CLI Flags:**
 
- - -n
- - --ensure-newline-before-comments
+- -n
+- --ensure-newline-before-comments
+
+**No Examples**
 
 ## Directory
+
 **No Description**
 
 **Type:** String  
@@ -632,9 +815,12 @@ Inserts a blank line before a comment following an import.
 **Python & Config File Name:** directory  
 **CLI Flags:**
 
- - **Not Supported**
+- **Not Supported**
+
+**No Examples**
 
 ## Profile
+
 Base profile type to use for configuration.
 
 **Type:** String  
@@ -642,9 +828,12 @@ Base profile type to use for configuration.
 **Python & Config File Name:** profile  
 **CLI Flags:**
 
- - --profile
+- --profile
+
+**No Examples**
 
 ## Src Paths
+
 Add an explicitly defined source path (modules within src paths have their imports automatically catorgorized as first_party).
 
 **Type:** Frozenset  
@@ -652,10 +841,13 @@ Add an explicitly defined source path (modules within src paths have their impor
 **Python & Config File Name:** src_paths  
 **CLI Flags:**
 
- - --src
- - --src-path
+- --src
+- --src-path
+
+**No Examples**
 
 ## Old Finders
+
 Use the old deprecated finder logic that relies on environment introspection magic.
 
 **Type:** Bool  
@@ -663,10 +855,13 @@ Use the old deprecated finder logic that relies on environment introspection mag
 **Python & Config File Name:** old_finders  
 **CLI Flags:**
 
- - --old-finders
- - --magic-placement
+- --old-finders
+- --magic-placement
+
+**No Examples**
 
 ## Check
+
 Checks the file for unsorted / unformatted imports and prints them to the command line without modifying the file.
 
 **Type:** Bool  
@@ -674,11 +869,14 @@ Checks the file for unsorted / unformatted imports and prints them to the comman
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - -c
- - --check-only
- - --check
+- -c
+- --check-only
+- --check
+
+**No Examples**
 
 ## Write To Stdout
+
 Force resulting output to stdout, instead of in-place.
 
 **Type:** Bool  
@@ -686,10 +884,13 @@ Force resulting output to stdout, instead of in-place.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - -d
- - --stdout
+- -d
+- --stdout
+
+**No Examples**
 
 ## Show Diff
+
 Prints a diff of all the changes isort would make to a file, instead of changing it in place
 
 **Type:** Bool  
@@ -697,10 +898,13 @@ Prints a diff of all the changes isort would make to a file, instead of changing
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --df
- - --diff
+- --df
+- --diff
+
+**No Examples**
 
 ## Jobs
+
 Number of files to process in parallel.
 
 **Type:** Int  
@@ -708,10 +912,13 @@ Number of files to process in parallel.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - -j
- - --jobs
+- -j
+- --jobs
+
+**No Examples**
 
 ## Dont Order By Type
+
 Don't order imports by type in addition to alphabetically
 
 **Type:** Bool  
@@ -719,10 +926,13 @@ Don't order imports by type in addition to alphabetically
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --dt
- - --dont-order-by-type
+- --dt
+- --dont-order-by-type
+
+**No Examples**
 
 ## Settings Path
+
 Explicitly set the settings path or file instead of auto determining based on file location.
 
 **Type:** String  
@@ -730,12 +940,15 @@ Explicitly set the settings path or file instead of auto determining based on fi
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --sp
- - --settings-path
- - --settings-file
- - --settings
+- --sp
+- --settings-path
+- --settings-file
+- --settings
+
+**No Examples**
 
 ## Show Version
+
 Displays the currently installed version of isort.
 
 **Type:** Bool  
@@ -743,10 +956,13 @@ Displays the currently installed version of isort.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - -V
- - --version
+- -V
+- --version
+
+**No Examples**
 
 ## Version Number
+
 Returns just the current version number without the logo
 
 **Type:** String  
@@ -754,10 +970,13 @@ Returns just the current version number without the logo
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --vn
- - --version-number
+- --vn
+- --version-number
+
+**No Examples**
 
 ## Filter Files
+
 Tells isort to filter files even when they are explicitly passed in as part of the command
 
 **Type:** Bool  
@@ -765,9 +984,12 @@ Tells isort to filter files even when they are explicitly passed in as part of t
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --filter-files
+- --filter-files
+
+**No Examples**
 
 ## Files
+
 One or more Python source files that need their imports sorted.
 
 **Type:** String  
@@ -775,9 +997,12 @@ One or more Python source files that need their imports sorted.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - 
+-
+
+**No Examples**
 
 ## Ask To Apply
+
 Tells isort to apply changes interactively.
 
 **Type:** Bool  
@@ -785,9 +1010,12 @@ Tells isort to apply changes interactively.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --interactive
+- --interactive
+
+**No Examples**
 
 ## Show Config
+
 See isort's determined config, as well as sources of config options.
 
 **Type:** Bool  
@@ -795,4 +1023,6 @@ See isort's determined config, as well as sources of config options.
 **Python & Config File Name:** **Not Supported**  
 **CLI Flags:**
 
- - --show-config
+- --show-config
+
+**No Examples**

--- a/isort/main.py
+++ b/isort/main.py
@@ -84,7 +84,9 @@ def sort_imports(
         skipped: bool = False
         if check:
             try:
-                incorrectly_sorted = not api.check_file(file_name, config=config, **kwargs)
+                incorrectly_sorted = not api.check_file(
+                    file_name, config=config, **kwargs
+                )
             except FileSkipped:
                 skipped = True
             return SortAttempt(incorrectly_sorted, skipped)
@@ -105,11 +107,15 @@ def sort_imports(
         return None
 
 
-def iter_source_code(paths: Iterable[str], config: Config, skipped: List[str]) -> Iterator[str]:
+def iter_source_code(
+    paths: Iterable[str], config: Config, skipped: List[str]
+) -> Iterator[str]:
     """Iterate over all Python source files defined in paths."""
     for path in paths:
         if os.path.isdir(path):
-            for dirpath, dirnames, filenames in os.walk(path, topdown=True, followlinks=True):
+            for dirpath, dirnames, filenames in os.walk(
+                path, topdown=True, followlinks=True
+            ):
                 base_path = Path(dirpath)
                 for dirname in list(dirnames):
                     if config.is_skipped(base_path / dirname):
@@ -278,12 +284,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-i",
         "--indent",
-        help='String to place for indents defaults to "    " (4 spaces).',
+        help='String to place for indents defaults to `"    "` (4 spaces).',
         dest="indent",
         type=str,
     )
     parser.add_argument(
-        "-j", "--jobs", help="Number of files to process in parallel.", dest="jobs", type=int
+        "-j",
+        "--jobs",
+        help="Number of files to process in parallel.",
+        dest="jobs",
+        type=int,
     )
     parser.add_argument(
         "-k",
@@ -292,8 +302,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Turns off default behavior that removes direct imports when as imports exist.",
     )
-    parser.add_argument("--lai", "--lines-after-imports", dest="lines_after_imports", type=int)
-    parser.add_argument("--lbt", "--lines-between-types", dest="lines_between_types", type=int)
+    parser.add_argument(
+        "--lai", "--lines-after-imports", dest="lines_after_imports", type=int
+    )
+    parser.add_argument(
+        "--lbt", "--lines-between-types", dest="lines_between_types", type=int
+    )
     parser.add_argument(
         "--le",
         "--line-ending",
@@ -524,7 +538,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "part of the command",
     )
     parser.add_argument(
-        "files", nargs="*", help="One or more Python source files that need their imports sorted."
+        "files",
+        nargs="*",
+        help="One or more Python source files that need their imports sorted.",
     )
     parser.add_argument(
         "--py",
@@ -569,7 +585,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> Dict[str, Any]:
     parser = _build_arg_parser()
-    arguments = {key: value for key, value in vars(parser.parse_args(argv)).items() if value}
+    arguments = {
+        key: value for key, value in vars(parser.parse_args(argv)).items() if value
+    }
     if "dont_order_by_type" in arguments:
         arguments["order_by_type"] = False
     multi_line_output = arguments.get("multi_line_output", None)
@@ -593,7 +611,9 @@ def _preconvert(item):
         raise TypeError("Unserializable object {} of type {}".format(item, type(item)))
 
 
-def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = None) -> None:
+def main(
+    argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = None
+) -> None:
     arguments = parse_args(argv)
     if arguments.get("show_version"):
         print(ASCII_ART)
@@ -650,7 +670,11 @@ def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = 
 
     config = Config(**config_dict)
     if show_config:
-        print(json.dumps(config.__dict__, indent=4, separators=(",", ": "), default=_preconvert))
+        print(
+            json.dumps(
+                config.__dict__, indent=4, separators=(",", ": "), default=_preconvert
+            )
+        )
         return
 
     wrong_sorted_files = False

--- a/isort/main.py
+++ b/isort/main.py
@@ -84,9 +84,7 @@ def sort_imports(
         skipped: bool = False
         if check:
             try:
-                incorrectly_sorted = not api.check_file(
-                    file_name, config=config, **kwargs
-                )
+                incorrectly_sorted = not api.check_file(file_name, config=config, **kwargs)
             except FileSkipped:
                 skipped = True
             return SortAttempt(incorrectly_sorted, skipped)
@@ -107,15 +105,11 @@ def sort_imports(
         return None
 
 
-def iter_source_code(
-    paths: Iterable[str], config: Config, skipped: List[str]
-) -> Iterator[str]:
+def iter_source_code(paths: Iterable[str], config: Config, skipped: List[str]) -> Iterator[str]:
     """Iterate over all Python source files defined in paths."""
     for path in paths:
         if os.path.isdir(path):
-            for dirpath, dirnames, filenames in os.walk(
-                path, topdown=True, followlinks=True
-            ):
+            for dirpath, dirnames, filenames in os.walk(path, topdown=True, followlinks=True):
                 base_path = Path(dirpath)
                 for dirname in list(dirnames):
                     if config.is_skipped(base_path / dirname):
@@ -284,16 +278,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-i",
         "--indent",
-        help='String to place for indents defaults to `"    "` (4 spaces).',
+        help='String to place for indents defaults to "    " (4 spaces).',
         dest="indent",
         type=str,
     )
     parser.add_argument(
-        "-j",
-        "--jobs",
-        help="Number of files to process in parallel.",
-        dest="jobs",
-        type=int,
+        "-j", "--jobs", help="Number of files to process in parallel.", dest="jobs", type=int
     )
     parser.add_argument(
         "-k",
@@ -302,12 +292,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Turns off default behavior that removes direct imports when as imports exist.",
     )
-    parser.add_argument(
-        "--lai", "--lines-after-imports", dest="lines_after_imports", type=int
-    )
-    parser.add_argument(
-        "--lbt", "--lines-between-types", dest="lines_between_types", type=int
-    )
+    parser.add_argument("--lai", "--lines-after-imports", dest="lines_after_imports", type=int)
+    parser.add_argument("--lbt", "--lines-between-types", dest="lines_between_types", type=int)
     parser.add_argument(
         "--le",
         "--line-ending",
@@ -538,9 +524,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "part of the command",
     )
     parser.add_argument(
-        "files",
-        nargs="*",
-        help="One or more Python source files that need their imports sorted.",
+        "files", nargs="*", help="One or more Python source files that need their imports sorted."
     )
     parser.add_argument(
         "--py",
@@ -585,9 +569,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> Dict[str, Any]:
     parser = _build_arg_parser()
-    arguments = {
-        key: value for key, value in vars(parser.parse_args(argv)).items() if value
-    }
+    arguments = {key: value for key, value in vars(parser.parse_args(argv)).items() if value}
     if "dont_order_by_type" in arguments:
         arguments["order_by_type"] = False
     multi_line_output = arguments.get("multi_line_output", None)
@@ -611,9 +593,7 @@ def _preconvert(item):
         raise TypeError("Unserializable object {} of type {}".format(item, type(item)))
 
 
-def main(
-    argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = None
-) -> None:
+def main(argv: Optional[Sequence[str]] = None, stdin: Optional[TextIOWrapper] = None) -> None:
     arguments = parse_args(argv)
     if arguments.get("show_version"):
         print(ASCII_ART)
@@ -670,11 +650,7 @@ def main(
 
     config = Config(**config_dict)
     if show_config:
-        print(
-            json.dumps(
-                config.__dict__, indent=4, separators=(",", ": "), default=_preconvert
-            )
-        )
+        print(json.dumps(config.__dict__, indent=4, separators=(",", ": "), default=_preconvert))
         return
 
     wrong_sorted_files = False

--- a/scripts/build_config_option_docs.py
+++ b/scripts/build_config_option_docs.py
@@ -8,9 +8,7 @@ from isort.main import _build_arg_parser
 from isort.settings import _DEFAULT_SETTINGS as config
 
 OUTPUT_FILE = os.path.abspath(
-    os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "../docs/configuration/options.md"
-    )
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../docs/configuration/options.md")
 )
 MD_NEWLINE = "  "
 HUMAN_NAME = {"py_version": "Python Version", "vn": "Version Number", "str": "String"}
@@ -44,11 +42,7 @@ class ConfigOption:
     example_cli: str = ""
 
     def __post_init__(self):
-        if (
-            self.example_cfg == ""
-            and self.example_pyproject_toml == ""
-            and self.example_cli == ""
-        ):
+        if self.example_cfg == "" and self.example_pyproject_toml == "" and self.example_cli == "":
             self.example_section = "**No Examples**"
         else:
             if self.example_cfg == "":
@@ -176,17 +170,12 @@ def config_options() -> Generator[ConfigOption, None, None]:
             extra_kwargs["description"] = cli.help
 
         yield ConfigOption(
-            name=name,
-            default=cli.default,
-            cli_options=cli.option_strings,
-            **extra_kwargs,
+            name=name, default=cli.default, cli_options=cli.option_strings, **extra_kwargs,
         )
 
 
 def document_text() -> str:
-    return (
-        f"{HEADER}{''.join(str(config_option) for config_option in config_options())}"
-    )
+    return f"{HEADER}{''.join(str(config_option) for config_option in config_options())}"
 
 
 def write_document():

--- a/scripts/build_config_option_docs.py
+++ b/scripts/build_config_option_docs.py
@@ -1,5 +1,6 @@
 #! /bin/env python
 import os
+import textwrap
 from typing import Any, Generator, Iterable, Type
 
 from isort._future import dataclass
@@ -7,14 +8,17 @@ from isort.main import _build_arg_parser
 from isort.settings import _DEFAULT_SETTINGS as config
 
 OUTPUT_FILE = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../docs/configuration/options.md")
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "../docs/configuration/options.md"
+    )
 )
 MD_NEWLINE = "  "
 HUMAN_NAME = {"py_version": "Python Version", "vn": "Version Number", "str": "String"}
 DESCRIPTIONS = {}
 IGNORED = {"source", "help"}
 COLUMNS = ["Name", "Type", "Default", "Python / Config file", "CLI", "Description"]
-HEADER = """Configuration options for isort
+HEADER = """# Configuration options for isort
+
 ========
 
 As a code formatter isort has opinions. However, it also allows you to have your own. If your opinions disagree with those of isort,
@@ -22,12 +26,11 @@ isort will disagree but commit to your way of formatting. To enable this, isort 
 how you want your imports sorted, organized, and formatted.
 
 Too busy to build your perfect isort configuration? For curated common configurations, see isort's [built-in profiles](https://timothycrosley.github.io/isort/docs/configuration/profiles/).
-
 """
 parser = _build_arg_parser()
 
 
-@dataclass(frozen=True)
+@dataclass
 class ConfigOption:
     name: str
     type: Type = str
@@ -35,14 +38,70 @@ class ConfigOption:
     config_name: str = "**Not Supported**"
     cli_options: Iterable[str] = ("**Not Supported**",)
     description: str = "**No Description**"
+    example_section: str = ""
+    example_cfg: str = ""
+    example_pyproject_toml: str = ""
+    example_cli: str = ""
+
+    def __post_init__(self):
+        if (
+            self.example_cfg == ""
+            and self.example_pyproject_toml == ""
+            and self.example_cli == ""
+        ):
+            self.example_section = "**No Examples**"
+        else:
+            if self.example_cfg == "":
+                self.example_cfg = "No example `.isort.cfg`"
+            else:
+                self.example_cfg = textwrap.dedent(
+                    f"""
+                    ### Example `.isort.cfg`
+
+                    ```
+                    {self.example_cfg}
+                    ```
+                    """
+                )
+
+            if self.example_pyproject_toml == "":
+                self.example_pyproject_toml = "No example pyproject.toml"
+            else:
+                self.example_pyproject_toml = textwrap.dedent(
+                    f"""
+                    ### Example `pyproject.toml`
+
+                    ```
+                    {self.example_pyproject_toml}
+                    ```
+                    """
+                )
+                print(self.example_pyproject_toml)
+
+            if self.example_cli == "":
+                self.example_cli = "No example cli usage"
+            else:
+                self.example_cli = textwrap.dedent(
+                    f"""
+                    ### Example cli usage
+                    `{self.example_cli}`
+                    """
+                )
+
+            self.example_section = f"""**Examples:**
+
+{self.example_cfg}
+{self.example_pyproject_toml}
+{self.example_cli}"""
 
     def __str__(self):
         if self.name in IGNORED:
             return ""
 
-        cli_options = "\n - ".join(self.cli_options)
+        cli_options = "\n- ".join(self.cli_options)
         return f"""
 ## {human(self.name)}
+
 {self.description}
 
 **Type:** {human(self.type.__name__)}{MD_NEWLINE}
@@ -50,7 +109,9 @@ class ConfigOption:
 **Python & Config File Name:** {self.config_name}{MD_NEWLINE}
 **CLI Flags:**
 
- - {cli_options}
+- {cli_options}
+
+{self.example_section}
 """
 
 
@@ -75,9 +136,34 @@ def config_options() -> Generator[ConfigOption, None, None]:
             if cli.help:
                 extra_kwargs["description"] = cli.help
 
-        yield ConfigOption(
-            name=name, type=type(default), default=default, config_name=name, **extra_kwargs
-        )
+        default_display = default
+        if isinstance(default, (set, frozenset)) and len(default) > 0:
+            default_display = tuple(i for i in sorted(default))
+
+        # todo: refactor place for example params
+        # needs to integrate with isort/settings/_Config
+        # needs to integrate with isort/main/_build_arg_parser
+        if name != "known_other":
+            yield ConfigOption(
+                name=name,
+                type=type(default),
+                default=default_display,
+                config_name=name,
+                **extra_kwargs,
+            )
+        else:
+            yield ConfigOption(
+                name=name,
+                type=type(default),
+                default=default_display,
+                config_name=name,
+                example_pyproject_toml=textwrap.dedent(
+                    """[tool.isort]
+                    sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'AIRFLOW', 'FIRSTPARTY', 'LOCALFOLDER']
+                    known_airflow = ['airflow']"""
+                ),
+                **extra_kwargs,
+            )
 
     for name, cli in cli_actions.items():
         extra_kwargs = {}
@@ -90,12 +176,17 @@ def config_options() -> Generator[ConfigOption, None, None]:
             extra_kwargs["description"] = cli.help
 
         yield ConfigOption(
-            name=name, default=cli.default, cli_options=cli.option_strings, **extra_kwargs
+            name=name,
+            default=cli.default,
+            cli_options=cli.option_strings,
+            **extra_kwargs,
         )
 
 
 def document_text() -> str:
-    return f"{HEADER}{''.join(str(config_option) for config_option in config_options())}"
+    return (
+        f"{HEADER}{''.join(str(config_option) for config_option in config_options())}"
+    )
 
 
 def write_document():


### PR DESCRIPTION
# What Changed

1. Add example attributes to ConfgOption in `scripts/build_config_option_docs.py`
1. Add temporary example for `known_other`
1. Sort frozen sets in documentation
1. Modify `buid_config_option_docs.py` to output markdown that doesn't offend vscode markdown linter

# Why it Changed

Address #1262

1. Support for examples in documentation
1. I needed a place to demo the usage of the examples and I was unsure how to integrate it with your current solution
1. frozenset & set defaults should be sorted for easy of reading and to ensure the `build_config_option_docs` is deterministic
1. Linter was marking unneeded leading and trailing whitespace in certain places

# What is left to do

1. Determine proper place for storing examples