### PR TITLE
Fix documentation with missing dot '.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ isort mypythonfile.py mypythonfile2.py
 or recursively:
 
 ```bash
-isort
+isort .
 ```
 
 *which is equivalent to:*


### PR DESCRIPTION
Commit 11e2a74f5d379a68edaa064a0aeb70d8bcad9491 changed the line to
remove the '-rc' flag but seems to have accidentally removed the dot
character at the same time.