### PR TITLE
Remove not_skip. Fixes: #1271

### DIFF
--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -63,7 +63,6 @@ To use any of the listed profiles, use `isort --profile PROFILE_NAME` from the c
  - **lines_after_imports**: `2`
  - **lines_between_types**: `1`
  - **multi_line_output**: `3`
- - **not_skip**: `'__init__.py'`
  - **use_parentheses**: `True`
 
 #hug

--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -40,7 +40,6 @@ attrs = {
     "lines_after_imports": 2,
     "lines_between_types": 1,
     "multi_line_output": 3,
-    "not_skip": "__init__.py",
     "use_parentheses": True,
 }
 hug = {

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -34,7 +34,6 @@ known_third_party = kate
 ignore_frosted_errors = E103
 skip = build,.tox,venv
 balanced_wrapping = true
-not_skip = __init__.py
 """
 SHORT_IMPORT = "from third_party import lib1, lib2, lib3, lib4"
 SINGLE_FROM_IMPORT = "from third_party import lib1"


### PR DESCRIPTION
* Fixes: #1271
* It fixed `TypeError: __init__() got an unexpected keyword argument 'not_skip'`
