### PR TITLE
Fix typo in profile doc description build

### DIFF
--- a/scripts/build_profile_docs.py
+++ b/scripts/build_profile_docs.py
@@ -24,7 +24,7 @@ def format_profile(profile_name: str, profile: Dict[str, Any]) -> str:
     return f"""
 #{profile_name}
 
-{profile.get('descripiton', '')}
+{profile.get('description', '')}
 {options}
 """
 


### PR DESCRIPTION
None of the profiles actually contain a description so this is a no-op, but happened to notice.