### PR TITLE
Issue #1276: Fix a bug that creates only one line after triple quotes

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -178,10 +178,9 @@ def sorted_imports(
         tail = formatted_output[imports_tail:]
 
         for index, line in enumerate(tail):
-            in_quote = _in_quote
-            should_skip, _in_quote, *_ = parse.skip_line(
+            should_skip, in_quote, *_ = parse.skip_line(
                 line,
-                in_quote=_in_quote,
+                in_quote='',
                 index=len(formatted_output),
                 section_comments=parsed.section_comments,
             )
@@ -194,7 +193,10 @@ def sorted_imports(
                     continue
                 next_construct = line
                 break
-            elif not in_quote:
+            elif in_quote:
+                next_construct = line
+                break
+            else:
                 parts = line.split()
                 if (
                     len(parts) >= 3

--- a/isort/output.py
+++ b/isort/output.py
@@ -174,7 +174,6 @@ def sorted_imports(
 
     if len(formatted_output) > imports_tail:
         next_construct = ""
-        _in_quote: str = ""
         tail = formatted_output[imports_tail:]
 
         for index, line in enumerate(tail):

--- a/isort/output.py
+++ b/isort/output.py
@@ -180,7 +180,7 @@ def sorted_imports(
         for index, line in enumerate(tail):
             should_skip, in_quote, *_ = parse.skip_line(
                 line,
-                in_quote='',
+                in_quote="",
                 index=len(formatted_output),
                 section_comments=parsed.section_comments,
             )

--- a/isort/output.py
+++ b/isort/output.py
@@ -195,16 +195,6 @@ def sorted_imports(
             elif in_quote:
                 next_construct = line
                 break
-            else:
-                parts = line.split()
-                if (
-                    len(parts) >= 3
-                    and parts[1] == "="
-                    and "'" not in parts[0]
-                    and '"' not in parts[0]
-                ):
-                    next_construct = line
-                    break
 
         if config.lines_after_imports != -1:
             formatted_output[imports_tail:0] = ["" for line in range(config.lines_after_imports)]

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -119,6 +119,12 @@ def test_correct_space_between_imports() -> None:
     test_output_other = api.sort_code_string(test_input_other)
     assert test_output_other == "import sys\n\nprint('yo')\n"
 
+    test_input_inquotes = (
+        "import sys\n" "@my_decorator('''hello\nworld''')\n" "def my_method():\n" "    print('hello world')\n"
+    )
+    test_output_inquotes = api.sort_code_string(test_input_inquotes)
+    assert test_output_inquotes == "import sys\n" "\n\n" "@my_decorator('''hello\nworld''')\n" "def my_method():\n" "    print('hello world')\n"
+
 
 def test_sort_on_number() -> None:
     """Ensure numbers get sorted logically (10 > 9 not the other way around)"""

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -133,6 +133,9 @@ def test_correct_space_between_imports() -> None:
         "def my_method():\n"
         "    print('hello world')\n"
     )
+    test_input_assign = "import sys\nVAR = 1\n"
+    test_output_assign = api.sort_code_string(test_input_assign)
+    assert test_output_assign == "import sys\n\nVAR = 1\n"
 
 
 def test_sort_on_number() -> None:

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -120,10 +120,19 @@ def test_correct_space_between_imports() -> None:
     assert test_output_other == "import sys\n\nprint('yo')\n"
 
     test_input_inquotes = (
-        "import sys\n" "@my_decorator('''hello\nworld''')\n" "def my_method():\n" "    print('hello world')\n"
+        "import sys\n"
+        "@my_decorator('''hello\nworld''')\n"
+        "def my_method():\n"
+        "    print('hello world')\n"
     )
     test_output_inquotes = api.sort_code_string(test_input_inquotes)
-    assert test_output_inquotes == "import sys\n" "\n\n" "@my_decorator('''hello\nworld''')\n" "def my_method():\n" "    print('hello world')\n"
+    assert (
+        test_output_inquotes == "import sys\n"
+        "\n\n"
+        "@my_decorator('''hello\nworld''')\n"
+        "def my_method():\n"
+        "    print('hello world')\n"
+    )
 
 
 def test_sort_on_number() -> None:


### PR DESCRIPTION
I think these sections are to find the first line after the tail of imports and I think it does not have to parse anymore when the line is in quotes

https://github.com/timothycrosley/isort/blob/develop/isort/output.py#L180-L206