### PR TITLE
Fix typo in plone profile

### DIFF
--- a/isort/profiles.py
+++ b/isort/profiles.py
@@ -30,7 +30,7 @@ open_stack = {
 plone = {
     "force_alphabetical_sort": True,
     "force_single_line": True,
-    "ines_after_imports": 2,
+    "lines_after_imports": 2,
     "line_length": 200,
 }
 attrs = {


### PR DESCRIPTION
Fix typo in `plone` profile missing for the setting `lines_after_imports`