### PR TITLE
Use correct spelling for use_parentheses

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -374,7 +374,7 @@ Balances wrapping to produce the most consistent line length possible
 
 ## Use Parentheses
 
-Use parenthesis for line continuation on length limit instead of slashes.
+Use parentheses for line continuation on length limit instead of slashes.
 
 **Type:** Bool  
 **Default:** `False`  


### PR DESCRIPTION
The spelling of this configuration option was updated, but the documentation still uses the old spelling.