### PR TITLE
Flake8 config cleanup.

### DIFF
--- a/isort/__init__.py
+++ b/isort/__init__.py
@@ -1,5 +1,5 @@
 """Defines the public isort interface"""
-from . import settings  # noqa: F401
+from . import settings
 from ._version import __version__
 from .api import check_code_string as check_code
 from .api import check_file, check_stream, place_module, place_module_with_reason

--- a/isort/api.py
+++ b/isort/api.py
@@ -21,8 +21,8 @@ from .format import (
     show_unified_diff,
 )
 from .io import Empty
-from .place import module as place_module  # skipcq: PYL-W0611 (intended export of public API)
-from .place import module_with_reason as place_module_with_reason  # skipcq: PYL-W0611 (^)
+from .place import module as place_module  # noqa: F401
+from .place import module_with_reason as place_module_with_reason  # noqa: F401
 from .settings import DEFAULT_CONFIG, FILE_SKIP_COMMENTS, Config
 
 CIMPORT_IDENTIFIERS = ("cimport ", "cimport*", "from.cimport")

--- a/isort/io.py
+++ b/isort/io.py
@@ -4,7 +4,7 @@ import tokenize
 from contextlib import contextmanager
 from io import BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
-from typing import Iterator, List, NamedTuple, Optional, TextIO, Tuple, Union
+from typing import Iterator, NamedTuple, TextIO, Union
 
 _ENCODING_PATTERN = re.compile(br"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 

--- a/isort/main.py
+++ b/isort/main.py
@@ -18,7 +18,7 @@ from .profiles import profiles
 from .settings import SUPPORTED_EXTENSIONS, VALID_PY_TARGETS, Config, WrapModes
 
 try:
-    from .setuptools_commands import ISortCommand  # skipcq: PYL-W0611
+    from .setuptools_commands import ISortCommand  # noqa: F401
 except ImportError:
     pass
 

--- a/isort/output.py
+++ b/isort/output.py
@@ -1,7 +1,7 @@
 import copy
 import itertools
 from functools import partial
-from typing import Dict, Iterable, List, Tuple
+from typing import Iterable, List, Tuple
 
 from isort.format import format_simplified
 

--- a/isort/place.py
+++ b/isort/place.py
@@ -3,7 +3,7 @@ import importlib
 from fnmatch import fnmatch
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 from isort import sections
 from isort.settings import DEFAULT_CONFIG, Config

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,6 +5,6 @@ poetry run cruft check
 poetry run mypy --ignore-missing-imports isort/
 poetry run black --check isort/ tests/
 poetry run isort --profile hug --check --diff isort/ tests/
-poetry run flake8 isort/ tests/ --max-line 100 --ignore F403,F401,W503,E203
+poetry run flake8 isort/ tests/
 poetry run safety check
 poetry run bandit -r isort/ -x isort/_vendored

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,11 @@ testpaths = tests
 
 [flake8]
 max-line-length = 100
-ignore = F403,F401,W503,E203
+# Ignore non PEP 8 compliant rules as suggested by black
+ignore =
+    W503  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-breaks--binary-operators
+    E203  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#slices
 exclude = _vendored
+per-file-ignores =
+    isort/__init__.py:F401
+    isort/stdlibs/__init__.py:F401

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from isort import api, exceptions
+from isort import api
 from isort.settings import Config
 
 

--- a/tests/test_deprecated_finders.py
+++ b/tests/test_deprecated_finders.py
@@ -4,8 +4,6 @@ import posixpath
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from isort import sections, settings
 from isort.deprecated import finders
 from isort.deprecated.finders import FindersManager

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,4 @@
 import os
-from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 from isort import exceptions, hooks

--- a/tests/test_importable.py
+++ b/tests/test_importable.py
@@ -38,4 +38,4 @@ def test_importable():
     import isort.wrap_modes
 
     with pytest.raises(SystemExit):
-        import isort.__main__
+        import isort.__main__  # noqa: F401

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -7,7 +7,6 @@ import os.path
 from pathlib import Path
 import subprocess
 import sys
-import sysconfig
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Iterator, List, Set, Tuple
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_setuptools_command.py
+++ b/tests/test_setuptools_command.py
@@ -1,8 +1,3 @@
-import os
-from unittest.mock import MagicMock
-
-import pytest
-
 from isort import setuptools_commands
 
 


### PR DESCRIPTION
Fixes #1311 

- specify flake8 config only in `setup.cfg` - removed passing in the same options in the `lint.sh` scripts as well
- remove `F401` and `F403` from the global ignore list
- added per-file `F401` ignores for `__init__.py` files and per-line `F401` ignores for all other cases
- removed unused import masked by global `F401` ignores
- changed DeepSource ignore comments to `# noqa: F401`, because those work for both flake8 and DeepSource
- added links to black documentation on why we choose to ignore `W503` and `E203` - the only globally ignored rules left
