### PR TITLE
Fix max_line_length parsing issue

### DIFF
--- a/isort/settings.py
+++ b/isort/settings.py
@@ -587,7 +587,7 @@ def _get_config_data(file_path: str, sections: Tuple[str]) -> Dict[str, Any]:
                 settings["indent"] = "\t" * (indent_size and int(indent_size) or 1)
 
             max_line_length = settings.pop("max_line_length", "").strip()
-            if max_line_length:
+            if (max_line_length and (max_line_length == "off" or isinstance(max_line_length, int) or max_line_length.isdigit())):
                 settings["line_length"] = (
                     float("inf") if max_line_length == "off" else int(max_line_length)
                 )

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -587,7 +587,7 @@ def _get_config_data(file_path: str, sections: Tuple[str]) -> Dict[str, Any]:
                 settings["indent"] = "\t" * (indent_size and int(indent_size) or 1)
 
             max_line_length = settings.pop("max_line_length", "").strip()
-            if (max_line_length and (max_line_length == "off" or isinstance(max_line_length, int) or max_line_length.isdigit())):
+            if (max_line_length and (max_line_length == "off" or max_line_length.isdigit())):
                 settings["line_length"] = (
                     float("inf") if max_line_length == "off" else int(max_line_length)
                 )


### PR DESCRIPTION
### Bug
Invalid value in `.editorconfig` file causes crash of isort.

**Example of invalid `.editorconfig`:**
```
[*]
max_line_length = null
```

### Current behaviour:
isort crashed with error:
```
File "/var/task/python/lib/python3.8/site-packages/isort/settings.py", line 229, in _update_with_config_file
computed_settings['line_length'] = float('inf') if max_line_length == 'off' else int(max_line_length)
ValueError: invalid literal for int() with base 10: 'null'
```

### Expected behaviour:
No crash.

**Simple fix:** just check if the `max_line_length` value is correct.
