### PR TITLE
Add property-based test with Hypothesmith

### DIFF
--- a/docs/contributing/4.-acknowledgements.md
+++ b/docs/contributing/4.-acknowledgements.md
@@ -184,6 +184,7 @@ Code Contributors
 - @nicolelodeon
 - Łukasz Langa (@ambv)
 - Grzegorz Pstrucha (@Gricha)
+- Zac Hatfield-Dodds (@Zac-HD)
 
 
 Documenters

--- a/poetry.lock
+++ b/poetry.lock
@@ -474,7 +474,7 @@ description = "A library for property-based testing"
 name = "hypothesis"
 optional = false
 python-versions = ">=3.5.2"
-version = "5.23.2"
+version = "5.23.8"
 
 [package.dependencies]
 attrs = ">=19.2.0"
@@ -505,6 +505,19 @@ pydantic = ">=0.32.2"
 
 [package.extras]
 pytest = ["pytest (>=4.0.0,<5.0.0)"]
+
+[[package]]
+category = "dev"
+description = "Hypothesis strategies for generating Python programs, something like CSmith"
+name = "hypothesmith"
+optional = false
+python-versions = ">=3.6"
+version = "0.1.3"
+
+[package.dependencies]
+hypothesis = ">=5.23.7"
+lark-parser = ">=0.7.2"
+libcst = ">=0.3.8"
 
 [[package]]
 category = "main"
@@ -628,6 +641,37 @@ name = "joblib"
 optional = false
 python-versions = ">=3.6"
 version = "0.16.0"
+
+[[package]]
+category = "dev"
+description = "a modern parsing library"
+name = "lark-parser"
+optional = false
+python-versions = "*"
+version = "0.9.0"
+
+[package.extras]
+regex = ["regex"]
+
+[[package]]
+category = "dev"
+description = "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs."
+name = "libcst"
+optional = false
+python-versions = ">=3.6"
+version = "0.3.8"
+
+[package.dependencies]
+pyyaml = ">=5.2"
+typing-extensions = ">=3.7.4.2"
+typing-inspect = ">=0.4.0"
+
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = "*"
+
+[package.extras]
+dev = ["black", "codecov", "coverage", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "isort", "flake8", "jupyter", "nbsphinx", "pyre-check", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 category = "dev"
@@ -1483,6 +1527,18 @@ python-versions = "*"
 version = "3.7.4.2"
 
 [[package]]
+category = "dev"
+description = "Runtime inspection utilities for typing module."
+name = "typing-inspect"
+optional = false
+python-versions = "*"
+version = "0.6.0"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
@@ -1796,12 +1852,16 @@ hyperframe = [
     {file = "hyperframe-5.2.0.tar.gz", hash = "sha256:a9f5c17f2cc3c719b917c4f33ed1c61bd1f8dfac4b1bd23b7c80b3400971b41f"},
 ]
 hypothesis = [
-    {file = "hypothesis-5.23.2-py3-none-any.whl", hash = "sha256:30f78de476f4db986570c43ef3a5c6ba4666bdf3a925e2bf7835215a8b08fe0f"},
-    {file = "hypothesis-5.23.2.tar.gz", hash = "sha256:d4048800a2f7b76f81baa9a31c1f102f18e7e37a9c038995e59d5f977e25003b"},
+    {file = "hypothesis-5.23.8-py3-none-any.whl", hash = "sha256:3d40ba66042b15d6653fb0360728007144f7e540efdfe0c81cdd38587d34583b"},
+    {file = "hypothesis-5.23.8.tar.gz", hash = "sha256:772e85dd18c9670891e0da1b585c6fb5cffb498a681a5feca94086a70bcef07a"},
 ]
 hypothesis-auto = [
     {file = "hypothesis-auto-1.1.4.tar.gz", hash = "sha256:5e2c2fb09dc09842512d80630bb792359a1d33d2c0473ad47ee23da0be9e32b1"},
     {file = "hypothesis_auto-1.1.4-py3-none-any.whl", hash = "sha256:fea8560c4522c0fd490ed8cc17e420b95dabebb11b9b334c59bf2d768839015f"},
+]
+hypothesmith = [
+    {file = "hypothesmith-0.1.3-py3-none-any.whl", hash = "sha256:aceb0feae6029eeaa4502cd763debec313b1aec43db8805958e5a81036c3e483"},
+    {file = "hypothesmith-0.1.3.tar.gz", hash = "sha256:4cf1e2ce43407ad1c9c2ab5a940760db3ea8c3c29134435bc0600f33a4a32de4"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1848,6 +1908,13 @@ jinja2-time = [
 joblib = [
     {file = "joblib-0.16.0-py3-none-any.whl", hash = "sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49"},
     {file = "joblib-0.16.0.tar.gz", hash = "sha256:8f52bf24c64b608bf0b2563e0e47d6fcf516abc8cfafe10cfd98ad66d94f92d6"},
+]
+lark-parser = [
+    {file = "lark-parser-0.9.0.tar.gz", hash = "sha256:9e7589365d6b6de1cca40b0eaec31104a3fb96a37a11a9dfd5098e95b50aa6cd"},
+]
+libcst = [
+    {file = "libcst-0.3.8-py3-none-any.whl", hash = "sha256:d514cd36e8da5e1444ec693b65a4b6751781af02496f9a2442c8590eb0d321fc"},
+    {file = "libcst-0.3.8.tar.gz", hash = "sha256:484fc3bf0b9b15773349548a466a36b137fbd94705fac8cdf25734fd8261fa17"},
 ]
 livereload = [
     {file = "livereload-2.6.2.tar.gz", hash = "sha256:d1eddcb5c5eb8d2ca1fa1f750e580da624c0f7fcb734aa5780dc81b7dcbd89be"},
@@ -2257,6 +2324,11 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
     {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.6.0-py2-none-any.whl", hash = "sha256:de08f50a22955ddec353876df7b2545994d6df08a2f45d54ac8c05e530372ca0"},
+    {file = "typing_inspect-0.6.0-py3-none-any.whl", hash = "sha256:3b98390df4d999a28cf5b35d8b333425af5da2ece8a4ea9e98f71e7591347b4f"},
+    {file = "typing_inspect-0.6.0.tar.gz", hash = "sha256:8f1b1dd25908dbfd81d3bebc218011531e7ab614ba6e5bf7826d887c834afab7"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ pytest-cov = "^2.7"
 pytest-mock = "^1.10"
 pep8-naming = "^0.8.2"
 hypothesis-auto = { version = "^1.0.0" }
+hypothesmith = "^0.1.3"
 examples = { version = "^1.0.0" }
 cruft = { version = "^1.1" }
 portray = { version = "^1.3.0" }

--- a/tests/test_hypothesmith.py
+++ b/tests/test_hypothesmith.py
@@ -1,0 +1,93 @@
+import ast
+from typing import get_type_hints
+
+import hypothesis
+import libcst
+from hypothesis import strategies as st
+from hypothesmith import from_grammar, from_node
+
+import isort
+
+
+def _as_config(kw) -> isort.Config:
+    if "wrap_length" in kw and "line_length" in kw:
+        kw["wrap_length"], kw["line_length"] = sorted([kw["wrap_length"], kw["line_length"]])
+    try:
+        return isort.Config(**kw)
+    except ValueError:
+        kw["wrap_length"] = 0
+        return isort.Config(**kw)
+
+
+def _record_targets(code: str, prefix: str = "") -> str:
+    # target larger inputs - the Hypothesis engine will do a multi-objective
+    # hill-climbing search using these scores to generate 'better' examples.
+    nodes = list(ast.walk(ast.parse(code)))
+    import_nodes = [n for n in nodes if isinstance(n, (ast.Import, ast.ImportFrom))]
+    uniq_nodes = {type(n) for n in nodes}
+    for value, label in [
+        (len(import_nodes), "total number of import nodes"),
+        (len(uniq_nodes), "number of unique ast node types"),
+    ]:
+        hypothesis.target(float(value), label=prefix + label)
+    return code
+
+
+def configs(**force_strategies: st.SearchStrategy) -> st.SearchStrategy[isort.Config]:
+    """Generate arbitrary Config objects."""
+    skip = {
+        "line_ending",
+        "sections",
+        "known_future_library",
+        "forced_separate",
+        "lines_after_imports",
+        "lines_between_sections",
+        "lines_between_types",
+        "sources",
+        "virtual_env",
+        "conda_env",
+        "directory",
+        "formatter",
+        "formatting_function",
+    }
+    inferred_kwargs = {
+        k: st.from_type(v)
+        for k, v in get_type_hints(isort.settings._Config).items()
+        if k not in skip
+    }
+    specific = {
+        "line_length": st.integers(0, 200),
+        "wrap_length": st.integers(0, 200),
+        "indent": st.integers(0, 20).map(lambda n: n * " "),
+        "default_section": st.sampled_from(sorted(isort.settings.KNOWN_SECTION_MAPPING)),
+        "force_grid_wrap": st.integers(0, 20),
+        "profile": st.sampled_from(sorted(isort.settings.profiles)),
+        "py_version": st.sampled_from(("auto",) + isort.settings.VALID_PY_TARGETS),
+    }
+    kwargs = {**inferred_kwargs, **specific, **force_strategies}
+    return st.fixed_dictionaries({}, optional=kwargs).map(_as_config)
+
+
+st.register_type_strategy(isort.Config, configs())
+
+
+@hypothesis.example("import A\nimportA\r\n\n", isort.Config(), False)
+@hypothesis.given(
+    source_code=st.lists(
+        from_grammar(auto_target=False)
+        | from_node(auto_target=False)
+        | from_node(libcst.Import, auto_target=False)
+        | from_node(libcst.ImportFrom, auto_target=False),
+        min_size=1,
+        max_size=10,
+    ).map("\n".join),
+    config=st.builds(isort.Config),
+    disregard_skip=st.booleans(),
+)
+@hypothesis.settings(suppress_health_check=[hypothesis.HealthCheck.too_slow])
+def test_isort_is_idempotent(source_code: str, config: isort.Config, disregard_skip: bool) -> None:
+    # NOTE: if this test finds a bug, please notify @Zac-HD so that it can be added to the
+    #       Hypothesmith trophy case.  This really helps with research impact evaluations!
+    _record_targets(source_code)
+    result = isort.code(source_code, config=config, disregard_skip=disregard_skip)
+    assert result == isort.code(result, config=config, disregard_skip=disregard_skip)


### PR DESCRIPTION
Hey @timothycrosley!  I saw https://github.com/Zac-HD/hypothesmith/issues/8 and thought I'd write you a pull request :smile: 

Notable features:
- custom strategy for `Config` objects to explore more weird edge cases
- custom composition of Hypothesmith strategies to boost number of import statements
- custom targeting logic to boost code complexity and number of import statements

Bugs that this can find (albeit with lowish probability):
- `"import A\nimportA\r\n\n"`, `importA` incorrectly treated as an import, unstable whitespace

Once you get it passing, I'd suggest using `while pytest -n=auto --dist=each tests/test_hypothesmith.py ; do : ; done` to soak up some CPU time looking for bugs overnight - if that doesn't find anything, it's unlikely that there's anything the test can find at all.