### PR TITLE
Adds length_sort_straight option

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -293,6 +293,19 @@ Sort imports by their string length.
 - --ls
 - --length-sort
 
+## Length Sort Straight Imports
+
+Sort straight imports by their string length. Similar to `length_sort` but applies only to
+straight imports and doesn't affect from imports.
+
+**Type:** Bool
+**Default:** `False`
+**Python & Config File Name:** length_sort_straight
+**CLI Flags:**
+
+- --lss
+- --length-sort-straight
+
 ## Length Sort Sections
 
 **No Description**

--- a/isort/main.py
+++ b/isort/main.py
@@ -328,6 +328,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     parser.add_argument(
+        "--lss",
+        "--length-sort-straight",
+        help="Sort straight imports by their string length.",
+        dest="length_sort_straight",
+        action="store_true",
+    )
+    parser.add_argument(
         "-m",
         "--multi-line",
         dest="multi_line_output",

--- a/isort/output.py
+++ b/isort/output.py
@@ -51,7 +51,10 @@ def sorted_imports(
     for section in sections:
         straight_modules = parsed.imports[section]["straight"]
         straight_modules = sorting.naturally(
-            straight_modules, key=lambda key: sorting.module_key(key, config, section_name=section)
+            straight_modules,
+            key=lambda key: sorting.module_key(
+                key, config, section_name=section, straight_import=True
+            ),
         )
         from_modules = parsed.imports[section]["from"]
         from_modules = sorting.naturally(

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -132,6 +132,7 @@ class _Config:
     indent: str = " " * 4
     comment_prefix: str = "  #"
     length_sort: bool = False
+    length_sort_straight: bool = False
     length_sort_sections: FrozenSet[str] = frozenset()
     add_imports: FrozenSet[str] = frozenset()
     remove_imports: FrozenSet[str] = frozenset()

--- a/isort/sorting.py
+++ b/isort/sorting.py
@@ -13,6 +13,7 @@ def module_key(
     sub_imports: bool = False,
     ignore_case: bool = False,
     section_name: Optional[Any] = None,
+    straight_import: Optional[bool] = False,
 ) -> str:
     match = re.match(r"^(\.+)\s*(.*)", module_name)
     if match:
@@ -41,7 +42,11 @@ def module_key(
     if not config.case_sensitive:
         module_name = module_name.lower()
 
-    length_sort = config.length_sort or str(section_name).lower() in config.length_sort_sections
+    length_sort = (
+        config.length_sort
+        or (config.length_sort_straight and straight_import)
+        or str(section_name).lower() in config.length_sort_sections
+    )
     _length_sort_maybe = length_sort and (str(len(module_name)) + ":" + module_name) or module_name
     return f"{module_name in config.force_to_top and 'A' or 'B'}{prefix}{_length_sort_maybe}"
 

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -605,11 +605,33 @@ def test_length_sort() -> None:
     )
 
 
+def test_length_sort_straight() -> None:
+    """Test setting isort to sort straight imports on length instead of alphabetically."""
+    test_input = (
+        "import medium_sizeeeeeeeeeeeeee\n"
+        "import shortie\n"
+        "import looooooooooooooooooooooooooooooooooooooong\n"
+        "from medium_sizeeeeeeeeeeeeee import b\n"
+        "from shortie import c\n"
+        "from looooooooooooooooooooooooooooooooooooooong import a\n"
+    )
+    test_output = isort.code(test_input, length_sort_straight=True)
+    assert test_output == (
+        "import shortie\n"
+        "import medium_sizeeeeeeeeeeeeee\n"
+        "import looooooooooooooooooooooooooooooooooooooong\n"
+        "from looooooooooooooooooooooooooooooooooooooong import a\n"
+        "from medium_sizeeeeeeeeeeeeee import b\n"
+        "from shortie import c\n"
+    )
+
+
 def test_length_sort_section() -> None:
     """Test setting isort to sort on length instead of alphabetically for a specific section."""
     test_input = (
         "import medium_sizeeeeeeeeeeeeee\n"
         "import shortie\n"
+        "import datetime\n"
         "import sys\n"
         "import os\n"
         "import looooooooooooooooooooooooooooooooooooooong\n"
@@ -619,6 +641,7 @@ def test_length_sort_section() -> None:
     assert test_output == (
         "import os\n"
         "import sys\n"
+        "import datetime\n"
         "\n"
         "import looooooooooooooooooooooooooooooooooooooong\n"
         "import medium_sizeeeeeeeeeeeeea\n"


### PR DESCRIPTION
Does this look OK as a solution to resolve #1232?

Added a new option that length sorts just the straight imports. It is `off` by default. 
See it in action below with the examples of the OP:

```
▶ cat t.py            
from datetime import timedelta
from contextlib import ExitStack

import os
import datetime
import sys

▶ poetry run isort -d t.py --length-sort-straight
import os
import sys
import datetime
from contextlib import ExitStack
from datetime import timedelta
```

