### PR TITLE
Bugfix #1321: --combine-as loses comment

### DIFF
--- a/isort/output.py
+++ b/isort/output.py
@@ -301,6 +301,11 @@ def _with_from_imports(
                 new_section_output.extend(above_comments)
 
             if "*" in from_imports and config.combine_star:
+                if config.combine_as_imports:
+                    comments = list(comments or ())
+                    comments += parsed.categorized_comments["from"].pop(
+                        f"{module}.__combined_as__", []
+                    )
                 import_statement = wrap.line(
                     with_comments(
                         comments,
@@ -385,7 +390,6 @@ def _with_from_imports(
                         for as_import in as_imports[from_import]
                     )
 
-                star_import = False
                 if "*" in from_imports:
                     new_section_output.append(
                         with_comments(
@@ -396,7 +400,6 @@ def _with_from_imports(
                         )
                     )
                     from_imports.remove("*")
-                    star_import = True
                     comments = None
 
                 for from_import in copy.copy(from_imports):
@@ -428,15 +431,16 @@ def _with_from_imports(
                     )
                 ):
                     from_import_section.append(from_imports.pop(0))
-                if star_import:
-                    import_statement = import_start + (", ").join(from_import_section)
-                else:
-                    import_statement = with_comments(
-                        comments,
-                        import_start + (", ").join(from_import_section),
-                        removed=config.ignore_comments,
-                        comment_prefix=config.comment_prefix,
+                if config.combine_as_imports:
+                    comments = parsed.categorized_comments["from"].pop(
+                        f"{module}.__combined_as__", ()
                     )
+                import_statement = with_comments(
+                    comments,
+                    import_start + (", ").join(from_import_section),
+                    removed=config.ignore_comments,
+                    comment_prefix=config.comment_prefix,
+                )
                 if not from_import_section:
                     import_statement = ""
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -492,3 +492,31 @@ def test_windows_diff_too_large_misrepresentative_issue_1348(test_path):
     assert diff_output.read().endswith(
         "-1,5 +1,5 @@\n+import a\r\n import b\r\n" "-import a\r\n \r\n \r\n def func():\r\n"
     )
+
+
+def test_combine_as_does_not_lose_comments_issue_1321():
+    """Test to ensure isort doesn't lose comments when --combine-as is used.
+    See: https://github.com/timothycrosley/isort/issues/1321
+    """
+    test_input = """
+from foo import *  # noqa
+from foo import bar as quux  # other
+from foo import x as a  # noqa
+
+import operator as op  # op comment
+import datetime as dtime  # dtime comment
+
+from datetime import date as d  # dcomm
+from datetime import datetime as dt  # dtcomm
+"""
+
+    expected_output = """
+import datetime as dtime  # dtime comment
+import operator as op  # op comment
+from datetime import date as d, datetime as dt  # dcomm; dtcomm
+
+from foo import *  # noqa
+from foo import bar as quux, x as a  # other; noqa
+"""
+
+    assert isort.code(test_input, combine_as_imports=True) == expected_output


### PR DESCRIPTION
@timothycrosley please feel free to adjust if needed, but at least it gives you a hint on what is wrong.

Actually it the `# noqa` comment isn't lost, but it is combined up (incorrectly) into the '*' import, but because both of the comments are the same (ie. `noqa`) it is shown only once.
If you changed the second comment to someone else it would should up on the star import, again incorrectly.

BTW, I find it strange that `--combine-star` works for as imports as well.
Is that by design?
Wouldn't that break code that relies on those aliases?

