### PR TITLE
Fix the first known party path expansion

### DIFF
--- a/isort/deprecated/finders.py
+++ b/isort/deprecated/finders.py
@@ -85,14 +85,13 @@ class KnownPatternFinder(BaseFinder):
                 regexp = "^" + known_pattern.replace("*", ".*").replace("?", ".?") + "$"
                 self.known_patterns.append((re.compile(regexp), placement))
 
-    @staticmethod
-    def _parse_known_pattern(pattern: str) -> List[str]:
+    def _parse_known_pattern(self, pattern: str) -> List[str]:
         """Expand pattern if identified as a directory and return found sub packages"""
         if pattern.endswith(os.path.sep):
             patterns = [
                 filename
-                for filename in os.listdir(pattern)
-                if os.path.isdir(os.path.join(pattern, filename))
+                for filename in os.listdir(os.path.join(self.config.directory, pattern))
+                if os.path.isdir(os.path.join(self.config.directory, pattern, filename))
             ]
         else:
             patterns = [pattern]

--- a/isort/settings.py
+++ b/isort/settings.py
@@ -523,14 +523,13 @@ class Config(_Config):
         self._section_comments = tuple(f"# {heading}" for heading in self.import_headings.values())
         return self._section_comments
 
-    @staticmethod
-    def _parse_known_pattern(pattern: str) -> List[str]:
+    def _parse_known_pattern(self, pattern: str) -> List[str]:
         """Expand pattern if identified as a directory and return found sub packages"""
         if pattern.endswith(os.path.sep):
             patterns = [
                 filename
-                for filename in os.listdir(pattern)
-                if os.path.isdir(os.path.join(pattern, filename))
+                for filename in os.listdir(os.path.join(self.directory, pattern))
+                if os.path.isdir(os.path.join(self.directory, pattern, filename))
             ]
         else:
             patterns = [pattern]

--- a/tests/test_isort.py
+++ b/tests/test_isort.py
@@ -1072,27 +1072,33 @@ def test_thirdy_party_overrides_standard_section() -> None:
     assert test_output == "import os\nimport sys\n\nimport profile.test\n"
 
 
-def test_known_pattern_path_expansion() -> None:
+def test_known_pattern_path_expansion(tmpdir) -> None:
     """Test to ensure patterns ending with path sep gets expanded
     and nested packages treated as known patterns.
     """
+    src_dir = tmpdir.mkdir("src")
+    src_dir.mkdir("foo")
+    src_dir.mkdir("bar")
     test_input = (
         "from kate_plugin import isort_plugin\n"
         "import sys\n"
-        "import isort.settings\n"
+        "from foo import settings\n"
+        "import bar\n"
         "import this\n"
         "import os\n"
     )
     test_output = isort.code(
         code=test_input,
         default_section="THIRDPARTY",
-        known_first_party=["./", "this", "kate_plugin", "isort"],
+        known_first_party=["src/", "this", "kate_plugin"],
+        directory=str(tmpdir),
     )
     test_output_old_finder = isort.code(
         code=test_input,
         default_section="FIRSTPARTY",
         old_finders=True,
-        known_first_party=["./", "this", "kate_plugin", "isort"],
+        known_first_party=["src/", "this", "kate_plugin"],
+        directory=str(tmpdir),
     )
     assert (
         test_output_old_finder
@@ -1101,8 +1107,9 @@ def test_known_pattern_path_expansion() -> None:
             "import os\n"
             "import sys\n"
             "\n"
-            "import isort.settings\n"
+            "import bar\n"
             "import this\n"
+            "from foo import settings\n"
             "from kate_plugin import isort_plugin\n"
         )
     )


### PR DESCRIPTION
The first known party path expansion stopped working in 5.0.5. The test for this feature was incorrectly fixed in https://github.com/timothycrosley/isort/commit/1bef08e4a56b07301b5a88c4b79e677f3414173c#diff-3e6dbf50f49313d010ff846279b07462R920 This PR fixes that regression by relying on `Config.directory`.

Thanks @lundberg for the feature and helping out with this PR!